### PR TITLE
Clean up bid replacements and output selection

### DIFF
--- a/node/src/bin/space-cli.rs
+++ b/node/src/bin/space-cli.rs
@@ -262,7 +262,7 @@ impl SpaceCli {
     async fn send_request(
         &self,
         req: Option<RpcWalletRequest>,
-        auction_outputs: Option<u8>,
+        bidouts: Option<u8>,
         fee_rate: Option<u64>,
     ) -> Result<(), ClientError> {
         let fee_rate = fee_rate.map(|fee| FeeRate::from_sat_per_vb(fee).unwrap());
@@ -271,7 +271,7 @@ impl SpaceCli {
             .wallet_send_request(
                 &self.wallet,
                 RpcWalletTxBuilder {
-                    auction_outputs,
+                    bidouts,
                     requests: match req {
                         None => vec![],
                         Some(req) => vec![req],
@@ -533,7 +533,7 @@ async fn handle_commands(
             println!("{}", serde_json::to_string_pretty(&spaces)?);
         }
         Commands::ListBidOuts => {
-            let spaces = cli.client.wallet_list_auction_outputs(&cli.wallet).await?;
+            let spaces = cli.client.wallet_list_bidouts(&cli.wallet).await?;
             println!("{}", serde_json::to_string_pretty(&spaces)?);
         }
         Commands::ListSpaces => {

--- a/node/src/bin/space-cli.rs
+++ b/node/src/bin/space-cli.rs
@@ -9,7 +9,7 @@ use jsonrpsee::{
 };
 use protocol::{
     bitcoin::{Amount, FeeRate, OutPoint, Txid},
-    hasher::{KeyHasher},
+    hasher::KeyHasher,
     slabel::SLabel,
 };
 use serde::{Deserialize, Serialize};
@@ -224,9 +224,7 @@ enum Commands {
     },
     /// DNS encodes the space and calculates the SHA-256 hash
     #[command(name = "hashspace")]
-    HashSpace {
-        space: String,
-    },
+    HashSpace { space: String },
 }
 
 struct SpaceCli {
@@ -395,7 +393,7 @@ async fn handle_commands(
             let response = cli.client.get_spaceout(outpoint).await?;
             println!("{}", serde_json::to_string_pretty(&response)?);
         }
-        Commands::CreateWallet  => {
+        Commands::CreateWallet => {
             cli.client.wallet_create(&cli.wallet).await?;
         }
         Commands::LoadWallet => {
@@ -410,10 +408,11 @@ async fn handle_commands(
         Commands::ExportWallet { path } => {
             let result = cli.client.wallet_export(&cli.wallet).await?;
             let content = serde_json::to_string_pretty(&result).expect("result");
-            fs::write(path, content).map_err(|e|
-                ClientError::Custom(format!("Could not save to path: {}", e.to_string())))?;
+            fs::write(path, content).map_err(|e| {
+                ClientError::Custom(format!("Could not save to path: {}", e.to_string()))
+            })?;
         }
-        Commands::GetWalletInfo  => {
+        Commands::GetWalletInfo => {
             let result = cli.client.wallet_get_info(&cli.wallet).await?;
             println!("{}", serde_json::to_string_pretty(&result).expect("result"));
         }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -186,8 +186,8 @@ pub trait Rpc {
         wallet: &str,
     ) -> Result<Vec<WalletOutput>, ErrorObjectOwned>;
 
-    #[method(name = "walletlistauctionoutputs")]
-    async fn wallet_list_auction_outputs(
+    #[method(name = "walletlistbidouts")]
+    async fn wallet_list_bidouts(
         &self,
         wallet: &str,
     ) -> Result<Vec<DoubleUtxo>, ErrorObjectOwned>;
@@ -199,7 +199,7 @@ pub trait Rpc {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct RpcWalletTxBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub auction_outputs: Option<u8>,
+    pub bidouts: Option<u8>,
     pub requests: Vec<RpcWalletRequest>,
     pub fee_rate: Option<FeeRate>,
     pub dust: Option<Amount>,
@@ -764,13 +764,13 @@ impl RpcServer for RpcServerImpl {
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
     }
 
-    async fn wallet_list_auction_outputs(
+    async fn wallet_list_bidouts(
         &self,
         wallet: &str,
     ) -> Result<Vec<DoubleUtxo>, ErrorObjectOwned> {
         self.wallet(&wallet)
             .await?
-            .send_list_auction_outputs()
+            .send_list_bidouts()
             .await
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
     }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -1,4 +1,3 @@
-use crate::store::RolloutEntry;
 use std::{
     collections::BTreeMap, fs, io::Write, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc,
 };
@@ -23,8 +22,9 @@ use protocol::{
         OutPoint,
     },
     constants::ChainAnchor,
-    hasher::{BaseHash, SpaceKey},
+    hasher::{BaseHash, KeyHasher, SpaceKey},
     prepare::DataSource,
+    slabel::SLabel,
     FullSpaceOut, SpaceOut,
 };
 use serde::{Deserialize, Serialize};
@@ -33,8 +33,6 @@ use tokio::{
     sync::{broadcast, mpsc, oneshot, RwLock},
     task::JoinSet,
 };
-use protocol::hasher::KeyHasher;
-use protocol::slabel::SLabel;
 use wallet::{
     bdk_wallet as bdk, bdk_wallet::template::Bip86, bitcoin::hashes::Hash, export::WalletExport,
     DoubleUtxo, SpacesWallet, WalletConfig, WalletDescriptors, WalletInfo,
@@ -44,12 +42,11 @@ use crate::{
     config::ExtendedNetwork,
     node::{BlockMeta, TxEntry},
     source::BitcoinRpc,
-    store::{ChainState, LiveSnapshot},
+    store::{ChainState, LiveSnapshot, RolloutEntry, Sha256},
     wallets::{
         AddressKind, Balance, RpcWallet, TxResponse, WalletCommand, WalletOutput, WalletResponse,
     },
 };
-use crate::store::Sha256;
 
 pub(crate) type Responder<T> = oneshot::Sender<T>;
 
@@ -58,8 +55,6 @@ pub struct ServerInfo {
     pub chain: ExtendedNetwork,
     pub tip: ChainAnchor,
 }
-
-
 
 pub enum ChainStateCommand {
     GetTip {
@@ -107,11 +102,16 @@ pub trait Rpc {
     async fn get_server_info(&self) -> Result<ServerInfo, ErrorObjectOwned>;
 
     #[method(name = "getspace")]
-    async fn get_space(&self, space_or_hash: &str) -> Result<Option<FullSpaceOut>, ErrorObjectOwned>;
+    async fn get_space(
+        &self,
+        space_or_hash: &str,
+    ) -> Result<Option<FullSpaceOut>, ErrorObjectOwned>;
 
     #[method(name = "getspaceowner")]
-    async fn get_space_owner(&self, space_or_hash: &str)
-                             -> Result<Option<OutPoint>, ErrorObjectOwned>;
+    async fn get_space_owner(
+        &self,
+        space_or_hash: &str,
+    ) -> Result<Option<OutPoint>, ErrorObjectOwned>;
 
     #[method(name = "getspaceout")]
     async fn get_spaceout(&self, outpoint: OutPoint) -> Result<Option<SpaceOut>, ErrorObjectOwned>;
@@ -178,7 +178,7 @@ pub trait Rpc {
 
     #[method(name = "walletlistspaces")]
     async fn wallet_list_spaces(&self, wallet: &str)
-                                -> Result<Vec<WalletOutput>, ErrorObjectOwned>;
+        -> Result<Vec<WalletOutput>, ErrorObjectOwned>;
 
     #[method(name = "walletlistunspent")]
     async fn wallet_list_unspent(
@@ -187,10 +187,7 @@ pub trait Rpc {
     ) -> Result<Vec<WalletOutput>, ErrorObjectOwned>;
 
     #[method(name = "walletlistbidouts")]
-    async fn wallet_list_bidouts(
-        &self,
-        wallet: &str,
-    ) -> Result<Vec<DoubleUtxo>, ErrorObjectOwned>;
+    async fn wallet_list_bidouts(&self, wallet: &str) -> Result<Vec<DoubleUtxo>, ErrorObjectOwned>;
 
     #[method(name = "walletgetbalance")]
     async fn wallet_get_balance(&self, wallet: &str) -> Result<Balance, ErrorObjectOwned>;
@@ -573,7 +570,10 @@ impl RpcServer for RpcServerImpl {
         Ok(ServerInfo { chain, tip })
     }
 
-    async fn get_space(&self, space_or_hash: &str) -> Result<Option<FullSpaceOut>, ErrorObjectOwned> {
+    async fn get_space(
+        &self,
+        space_or_hash: &str,
+    ) -> Result<Option<FullSpaceOut>, ErrorObjectOwned> {
         let space_hash = get_space_key(space_or_hash)?;
 
         let info = self
@@ -764,10 +764,7 @@ impl RpcServer for RpcServerImpl {
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
     }
 
-    async fn wallet_list_bidouts(
-        &self,
-        wallet: &str,
-    ) -> Result<Vec<DoubleUtxo>, ErrorObjectOwned> {
+    async fn wallet_list_bidouts(&self, wallet: &str) -> Result<Vec<DoubleUtxo>, ErrorObjectOwned> {
         self.wallet(&wallet)
             .await?
             .send_list_bidouts()
@@ -992,17 +989,17 @@ impl AsyncChainState {
 
 fn get_space_key(space_or_hash: &str) -> Result<SpaceKey, ErrorObjectOwned> {
     if space_or_hash.len() != 64 {
-        return Ok(
-            SpaceKey::from(
-                Sha256::hash(SLabel::try_from(space_or_hash).map_err(|_| {
+        return Ok(SpaceKey::from(Sha256::hash(
+            SLabel::try_from(space_or_hash)
+                .map_err(|_| {
                     ErrorObjectOwned::owned(
                         -1,
                         "expected a space name prefixed with @ or a hex encoded space hash",
                         None::<String>,
                     )
-                })?.as_ref())
-            )
-        );
+                })?
+                .as_ref(),
+        )));
     }
 
     let mut hash = [0u8; 32];

--- a/node/src/store.rs
+++ b/node/src/store.rs
@@ -11,8 +11,14 @@ use std::{
 use anyhow::Result;
 use bincode::{config, Decode, Encode};
 use jsonrpsee::core::Serialize;
+use protocol::{
+    bitcoin::OutPoint,
+    constants::{ChainAnchor, ROLLOUT_BATCH_SIZE},
+    hasher::{BidKey, KeyHash, OutpointKey, SpaceKey},
+    prepare::DataSource,
+    Covenant, FullSpaceOut, SpaceOut,
+};
 use serde::Deserialize;
-use protocol::{bitcoin::OutPoint, constants::{ChainAnchor, ROLLOUT_BATCH_SIZE}, hasher::{BidKey, KeyHash, OutpointKey, SpaceKey}, prepare::DataSource, Covenant, FullSpaceOut, SpaceOut};
 use spacedb::{
     db::{Database, SnapshotIterator},
     fs::FileBackend,
@@ -23,7 +29,7 @@ use spacedb::{
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RolloutEntry {
     pub space: String,
-    pub value: u32
+    pub value: u32,
 }
 
 type SpaceDb = Database<Sha256Hasher>;
@@ -334,7 +340,13 @@ impl LiveSnapshot {
             let outpoint = self.get_space_outpoint(&spacehash)?;
             if let Some(outpoint) = outpoint {
                 if let Some(spaceout) = self.get_spaceout(&outpoint)? {
-                    spaceouts.push((priority, FullSpaceOut { txid: outpoint.txid, spaceout }));
+                    spaceouts.push((
+                        priority,
+                        FullSpaceOut {
+                            txid: outpoint.txid,
+                            spaceout,
+                        },
+                    ));
                 }
             }
         }

--- a/protocol/src/constants.rs
+++ b/protocol/src/constants.rs
@@ -68,11 +68,9 @@ impl ChainAnchor {
     };
 
     // Testnet4 activation block
-    pub const TESTNET4: fn() -> Self = || {
-        Self {
-            hash: BlockHash::all_zeros(),
-            height: 50_000,
-        }
+    pub const TESTNET4: fn() -> Self = || Self {
+        hash: BlockHash::all_zeros(),
+        height: 50_000,
     };
 
     // Testnet activation block

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -220,7 +220,10 @@ impl SpacesWallet {
     }
 
     /// List outputs that can be safely auctioned off
-    pub fn list_bidouts(&mut self, selection: &SpacesAwareCoinSelection) -> anyhow::Result<Vec<DoubleUtxo>> {
+    pub fn list_bidouts(
+        &mut self,
+        selection: &SpacesAwareCoinSelection,
+    ) -> anyhow::Result<Vec<DoubleUtxo>> {
         let mut unspent: Vec<LocalOutput> = self.spaces.list_unspent().collect();
         let mut not_auctioned = vec![];
 
@@ -290,7 +293,11 @@ impl SpacesWallet {
         Ok(not_auctioned)
     }
 
-    pub fn new_bid_psbt(&mut self, total_burned: Amount, selection: &SpacesAwareCoinSelection) -> anyhow::Result<(Psbt, DoubleUtxo)> {
+    pub fn new_bid_psbt(
+        &mut self,
+        total_burned: Amount,
+        selection: &SpacesAwareCoinSelection,
+    ) -> anyhow::Result<(Psbt, DoubleUtxo)> {
         let all: Vec<_> = self.list_bidouts(selection)?;
 
         let msg = if selection.confirmed_only {
@@ -490,7 +497,7 @@ impl SpacesWallet {
                     signature,
                     sighash_type,
                 }
-                    .to_vec(),
+                .to_vec(),
             );
             witness.push(&signing_info.script);
             witness.push(&signing_info.control_block.serialize());

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -220,7 +220,7 @@ impl SpacesWallet {
     }
 
     /// List outputs that can be safely auctioned off
-    pub fn list_auction_outputs(&mut self) -> anyhow::Result<Vec<DoubleUtxo>> {
+    pub fn list_bidouts(&mut self, selection: &SpacesAwareCoinSelection) -> anyhow::Result<Vec<DoubleUtxo>> {
         let mut unspent: Vec<LocalOutput> = self.spaces.list_unspent().collect();
         let mut not_auctioned = vec![];
 
@@ -263,6 +263,15 @@ impl SpacesWallet {
                 && is_connector_dust(utxo1.txout.value)
                 && !is_space_dust(utxo2.txout.value)
                 && utxo2.txout.is_magic_output()
+
+                // Exclude any outputs that we know to be spaces
+                && !selection.exclude_outputs.iter()
+                .any(|sel|
+                    sel.is_space &&
+                        (sel.outpoint == utxo1.outpoint || sel.outpoint == utxo2.outpoint)
+                )
+                // Check if confirmed only are required
+                && (!selection.confirmed_only || utxo1.confirmation_time.is_confirmed())
             {
                 not_auctioned.push(DoubleUtxo {
                     spend: FullTxOut {
@@ -281,12 +290,19 @@ impl SpacesWallet {
         Ok(not_auctioned)
     }
 
-    pub fn new_bid_psbt(&mut self, total_burned: Amount) -> anyhow::Result<(Psbt, DoubleUtxo)> {
-        let all = self.list_auction_outputs()?;
+    pub fn new_bid_psbt(&mut self, total_burned: Amount, selection: &SpacesAwareCoinSelection) -> anyhow::Result<(Psbt, DoubleUtxo)> {
+        let all: Vec<_> = self.list_bidouts(selection)?;
+
+        let msg = if selection.confirmed_only {
+            "The wallet already has an unconfirmed bid for this space in the mempool, but no \
+            confirmed bid utxos are available to replace it with a different amount."
+        } else {
+            "No bid outputs found"
+        };
 
         let placeholder = all
             .first()
-            .ok_or_else(|| anyhow::anyhow!("No placeholders found"))?
+            .ok_or_else(|| anyhow::anyhow!("{}", msg))?
             .clone();
 
         let refund_value = total_burned + placeholder.auction.txout.value;
@@ -474,7 +490,7 @@ impl SpacesWallet {
                     signature,
                     sighash_type,
                 }
-                .to_vec(),
+                    .to_vec(),
             );
             witness.push(&signing_info.script);
             witness.push(&signing_info.control_block.serialize());


### PR DESCRIPTION
This PR makes bid replacements more robust: Generally, If tx1 spends bidout1 then later tx2 replaces tx1 by also spending bidout1 then bdk may use outputs from tx1 to fund tx2, even though tx2 is technically replacing tx1.

We should avoid selecting unconfirmed outputs when doing tx replacements anyways as that could result in `replacement-adds-unconfirmed` from Bitcoin Core. BDK avoids this [here](https://github.com/bitcoindevkit/bdk/blob/b8c736c60d1c27c5b8549c24fb9366058d5f25f7/crates/wallet/src/wallet/mod.rs#L1987) during fee bumping.

This PR also adds an additional safety check during bidout selection to avoid selecting any spaces that look like bidouts.