### PR TITLE
Make default chain mainnet and add `--confirmed-only` option

### DIFF
--- a/node/src/bin/space-cli.rs
+++ b/node/src/bin/space-cli.rs
@@ -28,7 +28,7 @@ use wallet::export::WalletExport;
 #[command(version, about, long_about = None)]
 pub struct Args {
     /// Bitcoin network to use
-    #[arg(long, env = "SPACED_CHAIN")]
+    #[arg(long, env = "SPACED_CHAIN", default_value = "mainnet")]
     chain: ExtendedNetwork,
     /// Spaced RPC URL [default: based on specified chain]
     #[arg(long)]

--- a/node/src/bin/space-cli.rs
+++ b/node/src/bin/space-cli.rs
@@ -92,6 +92,8 @@ enum Commands {
         /// Fee rate to use in sat/vB
         #[arg(long, short)]
         fee_rate: Option<u64>,
+        #[arg(long, short, default_value = "false")]
+        confirmed_only: bool,
     },
     /// Register a won auction
     Register {
@@ -270,6 +272,7 @@ impl SpaceCli {
         req: Option<RpcWalletRequest>,
         bidouts: Option<u8>,
         fee_rate: Option<u64>,
+        confirmed_only: bool,
     ) -> Result<(), ClientError> {
         let fee_rate = fee_rate.map(|fee| FeeRate::from_sat_per_vb(fee).unwrap());
         let result = self
@@ -285,6 +288,7 @@ impl SpaceCli {
                     fee_rate,
                     dust: self.dust,
                     force: self.force,
+                    confirmed_only
                 },
             )
             .await?;
@@ -440,6 +444,7 @@ async fn handle_commands(
                 })),
                 None,
                 fee_rate,
+                false
             )
             .await?
         }
@@ -447,6 +452,7 @@ async fn handle_commands(
             space,
             amount,
             fee_rate,
+            confirmed_only
         } => {
             cli.send_request(
                 Some(RpcWalletRequest::Bid(BidParams {
@@ -455,11 +461,12 @@ async fn handle_commands(
                 })),
                 None,
                 fee_rate,
+                confirmed_only
             )
             .await?
         }
         Commands::CreateBidOuts { pairs, fee_rate } => {
-            cli.send_request(None, Some(pairs), fee_rate).await?
+            cli.send_request(None, Some(pairs), fee_rate, false).await?
         }
         Commands::Register {
             space,
@@ -473,6 +480,7 @@ async fn handle_commands(
                 })),
                 None,
                 fee_rate,
+                false
             )
             .await?
         }
@@ -489,6 +497,7 @@ async fn handle_commands(
                 })),
                 None,
                 fee_rate,
+                false
             )
             .await?
         }
@@ -504,6 +513,7 @@ async fn handle_commands(
                 })),
                 None,
                 fee_rate,
+                false
             )
             .await?
         }
@@ -532,6 +542,7 @@ async fn handle_commands(
                 })),
                 None,
                 fee_rate,
+                false
             )
             .await?;
         }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -45,7 +45,7 @@ pub struct Args {
     #[arg(long, env = "SPACED_DATA_DIR")]
     data_dir: Option<PathBuf>,
     /// Network to use
-    #[arg(long, env = "SPACED_CHAIN")]
+    #[arg(long, env = "SPACED_CHAIN", default_value = "mainnet")]
     chain: ExtendedNetwork,
     /// Number of concurrent workers allowed during syncing
     #[arg(short, long, env = "SPACED_JOBS", default_value = "8")]

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -210,6 +210,7 @@ pub struct RpcWalletTxBuilder {
     pub fee_rate: Option<FeeRate>,
     pub dust: Option<Amount>,
     pub force: bool,
+    pub confirmed_only: bool,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/node/src/wallets.rs
+++ b/node/src/wallets.rs
@@ -603,9 +603,9 @@ impl RpcWallet {
         if tx.bidouts.is_some() {
             builder = builder.bidouts(tx.bidouts.unwrap());
         }
-        builder = builder.force(tx.force);
 
-        let mut bid_replacement = false;
+        builder = builder.force(tx.force);
+        let mut bid_replacement = tx.confirmed_only;
 
         for req in tx.requests {
             match req {
@@ -800,8 +800,8 @@ impl RpcWallet {
                             if rpc.message.contains("replacement-adds-unconfirmed") {
                                 error_data.insert(
                                     "hint".to_string(),
-                                    "Competing bid in mempool but wallet has no confirmed bid \
-                                    outputs (required to replace mempool bids)"
+                                    "Competing bid in mempool but wallet must use confirmed bidouts and funding \
+                                    outputs to replace it. Try --confirmed-only"
                                         .to_string(),
                                 );
                             }


### PR DESCRIPTION
- Makes default chain `mainnet`
- Add `--confirmed-only` option for bid command. This makes it possible to replace mempool bids if you have confirmed funding outputs and confirmed bidouts.
