### PR TITLE
Sqlite backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0453232ace82dee0dd0b4c87a59bd90f7b53b314f3e0f61fe2ee7c8a16482289"
+
+[[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,39 +206,40 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bdk_chain"
-version = "0.16.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163b064557cee078e8ee5dd2c88944204506f7b2b1524f78e8fcba38c346da7b"
+checksum = "3bee1fe68ec0015bce2e4c1754ebbf18d70750a1f0103e3785d34e8959fe8fd7"
 dependencies = [
+ "bdk_core",
  "bitcoin",
  "miniscript",
+ "rusqlite",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
-name = "bdk_file_store"
-version = "0.13.0"
+name = "bdk_core"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180f7ef84b5da0e748f7884becb364f4d06d12734ec46b149b9f02600afdf011"
+checksum = "be5e187ee33d5f99f1997a700cc1dfa0524fd1de31e6414c612c9e89ccdaa133"
 dependencies = [
- "bdk_chain",
- "bincode 1.3.3",
+ "bitcoin",
+ "hashbrown 0.9.1",
  "serde",
 ]
 
 [[package]]
 name = "bdk_wallet"
-version = "1.0.0-alpha.13"
+version = "1.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2926afdbfc54ebf7df2caa51af5be4435b90c01c6fbe5578b51b7c2c0a264bd9"
+checksum = "627ad309b5dc5adec0491141d40fcb8d032209c373dd47a870c702e9e5eba36a"
 dependencies = [
  "bdk_chain",
  "bip39",
  "bitcoin",
- "getrandom",
- "js-sys",
  "miniscript",
- "rand",
+ "rand_core",
  "serde",
  "serde_json",
 ]
@@ -236,15 +255,6 @@ name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
@@ -714,6 +724,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,9 +924,31 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.8",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash 0.8.11",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "heck"
@@ -1151,7 +1195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1332,6 +1376,17 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.4.2",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1653,7 +1708,7 @@ dependencies = [
 name = "protocol"
 version = "0.0.5"
 dependencies = [
- "bincode 2.0.0-rc.3",
+ "bincode",
  "bitcoin",
  "log",
  "rand",
@@ -1869,6 +1924,20 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.4.2",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -2215,7 +2284,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "base64 0.22.1",
- "bincode 2.0.0-rc.3",
+ "bincode",
  "clap",
  "ctrlc",
  "directories",
@@ -2242,7 +2311,7 @@ name = "spacedb"
 version = "0.0.2"
 source = "git+https://github.com/spacesprotocol/spacedb?tag=0.0.2#74eec1903552eef475fc73beb66c8bce9b2cbd06"
 dependencies = [
- "bincode 2.0.0-rc.3",
+ "bincode",
  "hex",
  "libc",
  "sha2 0.10.6",
@@ -2625,6 +2694,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,10 +2725,9 @@ name = "wallet"
 version = "0.0.5"
 dependencies = [
  "anyhow",
- "bdk_file_store",
  "bdk_wallet",
  "bech32",
- "bincode 2.0.0-rc.3",
+ "bincode",
  "bitcoin",
  "ctrlc",
  "hex",
@@ -2952,6 +3026,26 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,12 +36,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0453232ace82dee0dd0b4c87a59bd90f7b53b314f3e0f61fe2ee7c8a16482289"
-
-[[package]]
-name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -206,34 +200,33 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bdk_chain"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bee1fe68ec0015bce2e4c1754ebbf18d70750a1f0103e3785d34e8959fe8fd7"
+checksum = "65db19f8952e6563c7c0ce38190b930ac57c02bb9f0da4f761e542639f99ed72"
 dependencies = [
  "bdk_core",
  "bitcoin",
  "miniscript",
  "rusqlite",
  "serde",
- "serde_json",
 ]
 
 [[package]]
 name = "bdk_core"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e187ee33d5f99f1997a700cc1dfa0524fd1de31e6414c612c9e89ccdaa133"
+checksum = "070ff23e275c978ca19d137a2ae3516262400868a04228394710b270d958afc6"
 dependencies = [
  "bitcoin",
- "hashbrown 0.9.1",
+ "hashbrown",
  "serde",
 ]
 
 [[package]]
 name = "bdk_wallet"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "627ad309b5dc5adec0491141d40fcb8d032209c373dd47a870c702e9e5eba36a"
+checksum = "35ea570993f0d1a486b0f9204f14abaf4601c26992982ac78157ef3eb0fb49ac"
 dependencies = [
  "bdk_chain",
  "bip39",
@@ -715,9 +708,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -737,9 +730,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
@@ -924,21 +917,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.4.8",
+ "ahash",
  "serde",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-dependencies = [
- "ahash 0.8.11",
 ]
 
 [[package]]
@@ -947,7 +931,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1195,7 +1179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1364,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libredox"
@@ -1959,9 +1943,9 @@ checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -2365,12 +2349,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -2737,6 +2722,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,8 +201,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "bdk_chain"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65db19f8952e6563c7c0ce38190b930ac57c02bb9f0da4f761e542639f99ed72"
+source = "git+https://github.com/buffrr/bdk.git?rev=43bca8643dec6fdda99e4a29bf88709729af349e#43bca8643dec6fdda99e4a29bf88709729af349e"
 dependencies = [
  "bdk_core",
  "bitcoin",
@@ -214,8 +213,7 @@ dependencies = [
 [[package]]
 name = "bdk_core"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "070ff23e275c978ca19d137a2ae3516262400868a04228394710b270d958afc6"
+source = "git+https://github.com/buffrr/bdk.git?rev=43bca8643dec6fdda99e4a29bf88709729af349e#43bca8643dec6fdda99e4a29bf88709729af349e"
 dependencies = [
  "bitcoin",
  "hashbrown",
@@ -225,8 +223,7 @@ dependencies = [
 [[package]]
 name = "bdk_wallet"
 version = "1.0.0-beta.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ea570993f0d1a486b0f9204f14abaf4601c26992982ac78157ef3eb0fb49ac"
+source = "git+https://github.com/buffrr/bdk.git?rev=43bca8643dec6fdda99e4a29bf88709729af349e#43bca8643dec6fdda99e4a29bf88709729af349e"
 dependencies = [
  "bdk_chain",
  "bip39",

--- a/node/src/bin/spaced.rs
+++ b/node/src/bin/spaced.rs
@@ -5,7 +5,7 @@ use env_logger::Env;
 use log::error;
 use spaced::{
     config::{safe_exit, Args},
-    rpc::{AsyncChainState, LoadedWallet, RpcServerImpl, WalletManager},
+    rpc::{AsyncChainState, RpcServerImpl, WalletLoadRequest, WalletManager},
     source::{BitcoinBlockSource, BitcoinRpc},
     store,
     sync::Spaced,
@@ -16,7 +16,6 @@ use tokio::{
     sync::{broadcast, mpsc},
     task::{JoinHandle, JoinSet},
 };
-use spaced::rpc::WalletLoadRequest;
 
 #[tokio::main]
 async fn main() {

--- a/node/src/bin/spaced.rs
+++ b/node/src/bin/spaced.rs
@@ -16,6 +16,7 @@ use tokio::{
     sync::{broadcast, mpsc},
     task::{JoinHandle, JoinSet},
 };
+use spaced::rpc::WalletLoadRequest;
 
 #[tokio::main]
 async fn main() {
@@ -53,7 +54,7 @@ impl Composer {
         }
     }
 
-    async fn setup_rpc_wallet(&mut self, spaced: &Spaced, rx: mpsc::Receiver<LoadedWallet>) {
+    async fn setup_rpc_wallet(&mut self, spaced: &Spaced, rx: mpsc::Receiver<WalletLoadRequest>) {
         let wallet_service = RpcWallet::service(
             spaced.network,
             spaced.rpc.clone(),

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -4,6 +4,8 @@ extern crate core;
 pub extern crate jsonrpsee;
 pub extern crate log;
 
+use std::time::{Duration, Instant};
+
 mod checker;
 pub mod config;
 pub mod node;
@@ -12,3 +14,19 @@ pub mod source;
 pub mod store;
 pub mod sync;
 pub mod wallets;
+
+fn std_wait<F>(mut predicate: F, wait: Duration)
+where
+    F: FnMut() -> bool,
+{
+    let start = Instant::now();
+    loop {
+        if predicate() {
+            break;
+        }
+        if start.elapsed() >= wait {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -4,6 +4,7 @@ extern crate core;
 pub extern crate jsonrpsee;
 pub extern crate log;
 
+mod checker;
 pub mod config;
 pub mod node;
 pub mod rpc;
@@ -11,4 +12,3 @@ pub mod source;
 pub mod store;
 pub mod sync;
 pub mod wallets;
-mod checker;

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -25,7 +25,7 @@ pub trait BlockSource {
     fn get_block_hash(&self, height: u32) -> Result<BlockHash, BitcoinRpcError>;
     fn get_block(&self, hash: &BlockHash) -> Result<Block, BitcoinRpcError>;
     fn get_median_time(&self) -> Result<u64, BitcoinRpcError>;
-    fn in_mempool(&self, txid: Txid) -> Result<bool, BitcoinRpcError>;
+    fn in_mempool(&self, txid: &Txid) -> Result<bool, BitcoinRpcError>;
     fn get_block_count(&self) -> Result<u64, BitcoinRpcError>;
     fn get_best_chain(&self) -> Result<ChainAnchor, BitcoinRpcError>;
 }

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -6,7 +6,7 @@ use std::{error::Error, fmt};
 use anyhow::{anyhow, Result};
 use bincode::{Decode, Encode};
 use protocol::{
-    bitcoin::{Amount, Block, BlockHash, OutPoint},
+    bitcoin::{Amount, Block, BlockHash, OutPoint, Txid},
     constants::{ChainAnchor, ROLLOUT_BATCH_SIZE, ROLLOUT_BLOCK_INTERVAL},
     hasher::{BidKey, KeyHasher, OutpointKey, SpaceKey},
     prepare::TxContext,
@@ -25,6 +25,7 @@ pub trait BlockSource {
     fn get_block_hash(&self, height: u32) -> Result<BlockHash, BitcoinRpcError>;
     fn get_block(&self, hash: &BlockHash) -> Result<Block, BitcoinRpcError>;
     fn get_median_time(&self) -> Result<u64, BitcoinRpcError>;
+    fn in_mempool(&self, txid: Txid) -> Result<bool, BitcoinRpcError>;
     fn get_block_count(&self) -> Result<u64, BitcoinRpcError>;
     fn get_best_chain(&self) -> Result<ChainAnchor, BitcoinRpcError>;
 }

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -25,7 +25,7 @@ pub trait BlockSource {
     fn get_block_hash(&self, height: u32) -> Result<BlockHash, BitcoinRpcError>;
     fn get_block(&self, hash: &BlockHash) -> Result<Block, BitcoinRpcError>;
     fn get_median_time(&self) -> Result<u64, BitcoinRpcError>;
-    fn in_mempool(&self, txid: &Txid) -> Result<bool, BitcoinRpcError>;
+    fn in_mempool(&self, txid: &Txid, height: u32) -> Result<bool, BitcoinRpcError>;
     fn get_block_count(&self) -> Result<u64, BitcoinRpcError>;
     fn get_best_chain(&self) -> Result<ChainAnchor, BitcoinRpcError>;
 }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -48,6 +48,7 @@ use crate::{
         WalletResponse,
     },
 };
+use crate::wallets::ListSpacesResponse;
 
 pub(crate) type Responder<T> = oneshot::Sender<T>;
 
@@ -198,7 +199,7 @@ pub trait Rpc {
 
     #[method(name = "walletlistspaces")]
     async fn wallet_list_spaces(&self, wallet: &str)
-        -> Result<Vec<WalletOutput>, ErrorObjectOwned>;
+        -> Result<ListSpacesResponse, ErrorObjectOwned>;
 
     #[method(name = "walletlistunspent")]
     async fn wallet_list_unspent(
@@ -782,7 +783,7 @@ impl RpcServer for RpcServerImpl {
     async fn wallet_list_spaces(
         &self,
         wallet: &str,
-    ) -> Result<Vec<WalletOutput>, ErrorObjectOwned> {
+    ) -> Result<ListSpacesResponse, ErrorObjectOwned> {
         self.wallet(&wallet)
             .await?
             .send_list_spaces()

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -35,10 +35,7 @@ use tokio::{
     sync::{broadcast, mpsc, oneshot, RwLock},
     task::JoinSet,
 };
-use wallet::{
-    bdk_wallet as bdk, bdk_wallet::template::Bip86, bitcoin::hashes::Hash, export::WalletExport,
-    DoubleUtxo, WalletConfig, WalletDescriptors, WalletInfo,
-};
+use wallet::{bdk_wallet as bdk, bdk_wallet::template::Bip86, bitcoin::hashes::Hash, export::WalletExport, Balance, DoubleUtxo, WalletConfig, WalletDescriptors, WalletInfo, WalletOutput};
 
 use crate::{
     checker::TxChecker,
@@ -47,7 +44,7 @@ use crate::{
     source::BitcoinRpc,
     store::{ChainState, LiveSnapshot, RolloutEntry, Sha256},
     wallets::{
-        AddressKind, Balance, RpcWallet, TxInfo, TxResponse, WalletCommand, WalletOutput,
+        AddressKind, RpcWallet, TxInfo, TxResponse, WalletCommand,
         WalletResponse,
     },
 };

--- a/node/src/source.rs
+++ b/node/src/source.rs
@@ -172,7 +172,7 @@ impl BitcoinRpc {
         let params = serde_json::json!([]);
         self.make_request("getblockchaininfo", params)
     }
-    pub fn get_mempool_entry(&self, txid: Txid) -> BitcoinRpcRequest {
+    pub fn get_mempool_entry(&self, txid: &Txid) -> BitcoinRpcRequest {
         let params = serde_json::json!([txid]);
 
         self.make_request("getmempoolentry", params)
@@ -824,7 +824,7 @@ impl BlockSource for BitcoinBlockSource {
         ))
     }
 
-    fn in_mempool(&self, txid: Txid) -> Result<bool, BitcoinRpcError> {
+    fn in_mempool(&self, txid: &Txid) -> Result<bool, BitcoinRpcError> {
         let result: Result<Value, _> = self
             .rpc
             .send_json_blocking(&self.client, &self.rpc.get_mempool_entry(txid));

--- a/node/src/source.rs
+++ b/node/src/source.rs
@@ -206,7 +206,7 @@ impl BitcoinRpc {
         &self,
         client: &reqwest::blocking::Client,
         tx: &Transaction,
-    ) -> Result<ConfirmationTime, BitcoinRpcError> {
+    ) -> Result<u64, BitcoinRpcError> {
         let txid: String = self.send_json_blocking(client, &self.send_raw_transaction(tx))?;
 
         const MAX_RETRIES: usize = 10;
@@ -219,7 +219,7 @@ impl BitcoinRpc {
             match res {
                 Ok(mem) => {
                     if let Some(time) = mem.get("time").and_then(|t| t.as_u64()) {
-                        return Ok(ConfirmationTime::Unconfirmed { last_seen: time });
+                        return Ok(time);
                     }
                 }
                 Err(e) => last_error = Some(e),

--- a/node/src/sync.rs
+++ b/node/src/sync.rs
@@ -165,6 +165,7 @@ impl Spaced {
             }
             match receiver.try_recv() {
                 Ok(event) => match event {
+                    BlockEvent::Tip(_) => {}
                     BlockEvent::Block(id, block) => {
                         self.handle_block(&mut node, id, block)?;
                         info!("block={} height={}", id.hash, id.height);

--- a/node/src/wallets.rs
+++ b/node/src/wallets.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::anyhow;
 use clap::ValueEnum;
 use futures::{stream::FuturesUnordered, StreamExt};
-use log::{error, info, warn};
+use log::{info, warn};
 use protocol::{
     bitcoin::Txid,
     constants::ChainAnchor,
@@ -22,7 +22,6 @@ use tokio::{
     sync::{broadcast, mpsc, mpsc::Receiver, oneshot},
 };
 use tokio::time::Instant;
-use protocol::bitcoin::BlockHash;
 use wallet::{address::SpaceAddress, bdk_wallet::{
     chain::{local_chain::CheckPoint, BlockId},
     KeychainKind,

--- a/node/tests/fetcher_tests.rs
+++ b/node/tests/fetcher_tests.rs
@@ -37,6 +37,7 @@ fn test_block_fetching_from_bitcoin_rpc() -> Result<()> {
             panic!("Test timed out after {:?}", timeout);
         }
         match receiver.try_recv() {
+            Ok(BlockEvent::Tip(_)) => {}
             Ok(BlockEvent::Block(id, _)) => {
                 height += 1;
                 if id.height == GENERATED_BLOCKS as u32 {

--- a/node/tests/integration_tests.rs
+++ b/node/tests/integration_tests.rs
@@ -499,6 +499,22 @@ async fn it_should_allow_applying_script_in_batch(rig: &TestRig) -> anyhow::Resu
 // Bob attempts to replace it but fails due to a lack of confirmed bid & funding utxos.
 // Eve, with confirmed bid outputs/funds, successfully replaces the bid.
 async fn it_should_replace_mempool_bids(rig: &TestRig) -> anyhow::Result<()> {
+    // make sure Bob runs out of confirmed bidouts
+    let bob_bidout_count = rig.spaced.client.wallet_list_bidouts(BOB)
+        .await.expect("get bidouts").len();
+    for i in 0..bob_bidout_count {
+        wallet_do(
+            rig,
+            BOB,
+            vec![RpcWalletRequest::Bid(BidParams {
+                name: format!("@test{}", i + 100),
+                amount: 200,
+            })],
+            false,
+        )
+            .await.expect("bob makes a bid");
+    }
+
     // create some confirmed bid outs for Alice and Eve
     rig.spaced
         .client

--- a/node/tests/integration_tests.rs
+++ b/node/tests/integration_tests.rs
@@ -1,12 +1,19 @@
-use std::path::{PathBuf};
-use std::str::FromStr;
-use protocol::bitcoin::{Amount, FeeRate};
-use protocol::constants::RENEWAL_INTERVAL;
-use protocol::{Covenant};
-use protocol::script::SpaceScript;
-use spaced::rpc::{BidParams, ExecuteParams, OpenParams, RegisterParams, RpcClient, RpcWalletRequest, RpcWalletTxBuilder, TransferSpacesParams};
-use spaced::wallets::{AddressKind, WalletResponse};
-use testutil::{TestRig};
+use std::{path::PathBuf, str::FromStr};
+
+use protocol::{
+    bitcoin::{Amount, FeeRate},
+    constants::RENEWAL_INTERVAL,
+    script::SpaceScript,
+    Covenant,
+};
+use spaced::{
+    rpc::{
+        BidParams, ExecuteParams, OpenParams, RegisterParams, RpcClient, RpcWalletRequest,
+        RpcWalletTxBuilder, TransferSpacesParams,
+    },
+    wallets::{AddressKind, WalletResponse},
+};
+use testutil::TestRig;
 use wallet::export::WalletExport;
 
 const ALICE: &str = "wallet_99";
@@ -16,16 +23,20 @@ const EVE: &str = "wallet_93";
 const TEST_SPACE: &str = "@example123";
 const TEST_INITIAL_BID: u64 = 5000;
 
-
 /// alice opens [TEST_SPACE] for auction
 async fn it_should_open_a_space_for_auction(rig: &TestRig) -> anyhow::Result<()> {
     rig.wait_until_wallet_synced(ALICE).await?;
-    let response = wallet_do(rig, ALICE, vec![
-        RpcWalletRequest::Open(OpenParams {
+    let response = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Open(OpenParams {
             name: TEST_SPACE.to_string(),
             amount: TEST_INITIAL_BID,
-        }),
-    ], false).await.expect("send request");
+        })],
+        false,
+    )
+    .await
+    .expect("send request");
 
     for tx_res in &response.result {
         assert!(tx_res.error.is_none(), "expect no errors for simple open");
@@ -40,12 +51,21 @@ async fn it_should_open_a_space_for_auction(rig: &TestRig) -> anyhow::Result<()>
     let space = fullspaceout.spaceout.space.expect("a space");
 
     match space.covenant {
-        Covenant::Bid { total_burned, burn_increment, claim_height, .. } => {
+        Covenant::Bid {
+            total_burned,
+            burn_increment,
+            claim_height,
+            ..
+        } => {
             assert!(claim_height.is_none(), "none for pre-auctions");
             assert_eq!(total_burned, burn_increment, "equal for initial bid");
-            assert_eq!(total_burned, Amount::from_sat(TEST_INITIAL_BID), "must be equal to opened bid");
+            assert_eq!(
+                total_burned,
+                Amount::from_sat(TEST_INITIAL_BID),
+                "must be equal to opened bid"
+            );
         }
-        _ => panic!("expected a bid covenant")
+        _ => panic!("expected a bid covenant"),
     }
 
     Ok(())
@@ -62,13 +82,16 @@ async fn it_should_allow_outbidding(rig: &TestRig) -> anyhow::Result<()> {
     let alices_balance = rig.spaced.client.wallet_get_balance(ALICE).await?;
 
     let result = wallet_do(
-        rig, BOB,
-        vec![
-            RpcWalletRequest::Bid(BidParams {
-                name: TEST_SPACE.to_string(),
-                amount: TEST_INITIAL_BID + 1,
-            }),
-        ], false).await.expect("send request");
+        rig,
+        BOB,
+        vec![RpcWalletRequest::Bid(BidParams {
+            name: TEST_SPACE.to_string(),
+            amount: TEST_INITIAL_BID + 1,
+        })],
+        false,
+    )
+    .await
+    .expect("send request");
 
     println!("{}", serde_json::to_string_pretty(&result).unwrap());
     rig.mine_blocks(1, None).await?;
@@ -80,29 +103,55 @@ async fn it_should_allow_outbidding(rig: &TestRig) -> anyhow::Result<()> {
     let alice_spaces_updated = rig.spaced.client.wallet_list_spaces(ALICE).await?;
     let alices_balance_updated = rig.spaced.client.wallet_get_balance(ALICE).await?;
 
-    assert_eq!(alices_spaces.len() - 1, alice_spaces_updated.len(), "alice must have one less space");
-    assert_eq!(bobs_spaces.len() + 1, bob_spaces_updated.len(), "bob must have a new space");
-    assert_eq!(alices_balance_updated.balance, alices_balance.balance +
-        Amount::from_sat(TEST_INITIAL_BID + 662), "alice must be refunded this exact amount");
+    assert_eq!(
+        alices_spaces.len() - 1,
+        alice_spaces_updated.len(),
+        "alice must have one less space"
+    );
+    assert_eq!(
+        bobs_spaces.len() + 1,
+        bob_spaces_updated.len(),
+        "bob must have a new space"
+    );
+    assert_eq!(
+        alices_balance_updated.balance,
+        alices_balance.balance + Amount::from_sat(TEST_INITIAL_BID + 662),
+        "alice must be refunded this exact amount"
+    );
 
     let fullspaceout = rig.spaced.client.get_space(TEST_SPACE).await?;
     let fullspaceout = fullspaceout.expect("a fullspace out");
     let space = fullspaceout.spaceout.space.expect("a space");
 
     match space.covenant {
-        Covenant::Bid { total_burned, burn_increment, claim_height, .. } => {
+        Covenant::Bid {
+            total_burned,
+            burn_increment,
+            claim_height,
+            ..
+        } => {
             assert!(claim_height.is_none(), "none for pre-auctions");
-            assert_eq!(total_burned, Amount::from_sat(TEST_INITIAL_BID + 1), "total burned");
-            assert_eq!(burn_increment, Amount::from_sat(1), "burn increment only 1 sat");
+            assert_eq!(
+                total_burned,
+                Amount::from_sat(TEST_INITIAL_BID + 1),
+                "total burned"
+            );
+            assert_eq!(
+                burn_increment,
+                Amount::from_sat(1),
+                "burn increment only 1 sat"
+            );
         }
-        _ => panic!("expected a bid covenant")
+        _ => panic!("expected a bid covenant"),
     }
 
     Ok(())
 }
 
 /// Eve makes an invalid bid with a burn increment of 0 only refunding Bob's money
-async fn it_should_only_accept_forced_zero_value_bid_increments_and_revoke(rig: &TestRig) -> anyhow::Result<()> {
+async fn it_should_only_accept_forced_zero_value_bid_increments_and_revoke(
+    rig: &TestRig,
+) -> anyhow::Result<()> {
     // Bob outbids alice
     rig.wait_until_wallet_synced(BOB).await?;
     rig.wait_until_wallet_synced(EVE).await?;
@@ -110,60 +159,77 @@ async fn it_should_only_accept_forced_zero_value_bid_increments_and_revoke(rig: 
     let bob_spaces = rig.spaced.client.wallet_list_spaces(BOB).await?;
     let bob_balance = rig.spaced.client.wallet_get_balance(BOB).await?;
 
-    let fullspaceout = rig.spaced.client.get_space(TEST_SPACE).await?.expect("exists");
+    let fullspaceout = rig
+        .spaced
+        .client
+        .get_space(TEST_SPACE)
+        .await?
+        .expect("exists");
     let space = fullspaceout.spaceout.space.expect("a space");
     let last_bid = match space.covenant {
         Covenant::Bid { total_burned, .. } => total_burned,
-        _ => panic!("expected a bid")
+        _ => panic!("expected a bid"),
     };
 
-    assert!(wallet_do(
-        rig, EVE,
-        vec![
-            RpcWalletRequest::Bid(BidParams {
+    assert!(
+        wallet_do(
+            rig,
+            EVE,
+            vec![RpcWalletRequest::Bid(BidParams {
                 name: TEST_SPACE.to_string(),
                 amount: last_bid.to_sat(),
-            }),
-        ],
-        false).await.is_err(), "shouldn't be able to bid with same value unless forced");
+            }),],
+            false
+        )
+        .await
+        .is_err(),
+        "shouldn't be able to bid with same value unless forced"
+    );
 
     // force only
-    assert!(rig.spaced.client.wallet_send_request(
-        EVE,
-        RpcWalletTxBuilder {
-            bidouts: None,
-            requests: vec![
-                RpcWalletRequest::Bid(BidParams {
-                    name: TEST_SPACE.to_string(),
-                    amount: last_bid.to_sat(),
-                }),
-            ],
-            fee_rate: Some(FeeRate::from_sat_per_vb(1).expect("fee")),
-            dust: None,
-            force: true,
-            confirmed_only: false,
-            skip_tx_check: false,
-        },
-    ).await.is_err(), "should require skip tx check");
+    assert!(
+        rig.spaced
+            .client
+            .wallet_send_request(
+                EVE,
+                RpcWalletTxBuilder {
+                    bidouts: None,
+                    requests: vec![RpcWalletRequest::Bid(BidParams {
+                        name: TEST_SPACE.to_string(),
+                        amount: last_bid.to_sat(),
+                    }),],
+                    fee_rate: Some(FeeRate::from_sat_per_vb(1).expect("fee")),
+                    dust: None,
+                    force: true,
+                    confirmed_only: false,
+                    skip_tx_check: false,
+                },
+            )
+            .await
+            .is_err(),
+        "should require skip tx check"
+    );
 
     // force & skip tx check
-    let result = rig.spaced.client.wallet_send_request(
-        EVE,
-        RpcWalletTxBuilder {
-            bidouts: None,
-            requests: vec![
-                RpcWalletRequest::Bid(BidParams {
+    let result = rig
+        .spaced
+        .client
+        .wallet_send_request(
+            EVE,
+            RpcWalletTxBuilder {
+                bidouts: None,
+                requests: vec![RpcWalletRequest::Bid(BidParams {
                     name: TEST_SPACE.to_string(),
                     amount: last_bid.to_sat(),
-                }),
-            ],
-            fee_rate: Some(FeeRate::from_sat_per_vb(1).expect("fee")),
-            dust: None,
-            force: true,
-            confirmed_only: false,
-            skip_tx_check: true,
-        },
-    ).await?;
+                })],
+                fee_rate: Some(FeeRate::from_sat_per_vb(1).expect("fee")),
+                dust: None,
+                force: true,
+                confirmed_only: false,
+                skip_tx_check: true,
+            },
+        )
+        .await?;
 
     println!("{}", serde_json::to_string_pretty(&result).unwrap());
     rig.mine_blocks(1, None).await?;
@@ -175,10 +241,21 @@ async fn it_should_only_accept_forced_zero_value_bid_increments_and_revoke(rig: 
     let bob_balance_updated = rig.spaced.client.wallet_get_balance(BOB).await?;
     let eve_spaces_updated = rig.spaced.client.wallet_list_spaces(EVE).await?;
 
-    assert_eq!(bob_spaces.len() - 1, bob_spaces_updated.len(), "bob must have one less space");
-    assert_eq!(bob_balance_updated.balance, bob_balance.balance +
-        Amount::from_sat(last_bid.to_sat() + 662), "alice must be refunded this exact amount");
-    assert_eq!(eve_spaces_updated.len(), eve_spaces.len(), "eve must have the same number of spaces");
+    assert_eq!(
+        bob_spaces.len() - 1,
+        bob_spaces_updated.len(),
+        "bob must have one less space"
+    );
+    assert_eq!(
+        bob_balance_updated.balance,
+        bob_balance.balance + Amount::from_sat(last_bid.to_sat() + 662),
+        "alice must be refunded this exact amount"
+    );
+    assert_eq!(
+        eve_spaces_updated.len(),
+        eve_spaces.len(),
+        "eve must have the same number of spaces"
+    );
 
     let fullspaceout = rig.spaced.client.get_space(TEST_SPACE).await?;
     assert!(fullspaceout.is_none(), "must be revoked");
@@ -188,25 +265,39 @@ async fn it_should_only_accept_forced_zero_value_bid_increments_and_revoke(rig: 
 async fn it_should_allow_claim_on_or_after_claim_height(rig: &TestRig) -> anyhow::Result<()> {
     let wallet = EVE;
     let claimable_space = "@test9880";
-    let space = rig.spaced.client.get_space(claimable_space).await?
+    let space = rig
+        .spaced
+        .client
+        .get_space(claimable_space)
+        .await?
         .expect(claimable_space);
     let space = space.spaceout.space.expect(claimable_space);
 
     let current_height = rig.get_block_count().await?;
     let claim_height = space.claim_height().expect("height") as u64;
-    rig.mine_blocks((claim_height - current_height) as _, None).await?;
+    rig.mine_blocks((claim_height - current_height) as _, None)
+        .await?;
 
-    assert_eq!(claim_height, rig.get_block_count().await?, "heights must match");
+    assert_eq!(
+        claim_height,
+        rig.get_block_count().await?,
+        "heights must match"
+    );
 
     rig.wait_until_wallet_synced(wallet).await?;
     let all_spaces = rig.spaced.client.wallet_list_spaces(wallet).await?;
 
-    let result = wallet_do(rig, wallet, vec![
-        RpcWalletRequest::Register(RegisterParams {
+    let result = wallet_do(
+        rig,
+        wallet,
+        vec![RpcWalletRequest::Register(RegisterParams {
             name: claimable_space.to_string(),
             to: None,
-        }),
-    ], false).await.expect("send request");
+        })],
+        false,
+    )
+    .await
+    .expect("send request");
 
     println!("{}", serde_json::to_string_pretty(&result).unwrap());
     rig.mine_blocks(1, None).await?;
@@ -217,7 +308,11 @@ async fn it_should_allow_claim_on_or_after_claim_height(rig: &TestRig) -> anyhow
 
     assert_eq!(all_spaces.len(), all_spaces_2.len(), "must be equal");
 
-    let space = rig.spaced.client.get_space(claimable_space).await?
+    let space = rig
+        .spaced
+        .client
+        .get_space(claimable_space)
+        .await?
         .expect(claimable_space);
     let space = space.spaceout.space.expect(claimable_space);
 
@@ -228,26 +323,40 @@ async fn it_should_allow_claim_on_or_after_claim_height(rig: &TestRig) -> anyhow
     Ok(())
 }
 
-async fn it_should_allow_batch_transfers_refreshing_expire_height(rig: &TestRig) -> anyhow::Result<()> {
+async fn it_should_allow_batch_transfers_refreshing_expire_height(
+    rig: &TestRig,
+) -> anyhow::Result<()> {
     rig.wait_until_wallet_synced(ALICE).await?;
     rig.wait_until_synced().await?;
     let all_spaces = rig.spaced.client.wallet_list_spaces(ALICE).await?;
-    let registered_spaces: Vec<_> = all_spaces.iter().filter_map(|s| {
-        let space = s.space.as_ref().expect("space");
-        match space.covenant {
-            Covenant::Transfer { .. } => Some(space.name.to_string()),
-            _ => None,
-        }
-    }).collect();
+    let registered_spaces: Vec<_> = all_spaces
+        .iter()
+        .filter_map(|s| {
+            let space = s.space.as_ref().expect("space");
+            match space.covenant {
+                Covenant::Transfer { .. } => Some(space.name.to_string()),
+                _ => None,
+            }
+        })
+        .collect();
 
-    let space_address = rig.spaced.client.wallet_get_new_address(ALICE, AddressKind::Space).await?;
+    let space_address = rig
+        .spaced
+        .client
+        .wallet_get_new_address(ALICE, AddressKind::Space)
+        .await?;
 
-    let result = wallet_do(rig, ALICE, vec![
-        RpcWalletRequest::Transfer(TransferSpacesParams {
+    let result = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Transfer(TransferSpacesParams {
             spaces: registered_spaces.clone(),
             to: space_address,
-        }),
-    ], false).await.expect("send request");
+        })],
+        false,
+    )
+    .await
+    .expect("send request");
 
     println!("{}", serde_json::to_string_pretty(&result).unwrap());
 
@@ -266,13 +375,24 @@ async fn it_should_allow_batch_transfers_refreshing_expire_height(rig: &TestRig)
         match space.covenant {
             Covenant::Transfer { expire_height, .. } => {
                 count += 1;
-                assert_eq!(expire_height, expected_expire_height, "must refresh expire height");
+                assert_eq!(
+                    expire_height, expected_expire_height,
+                    "must refresh expire height"
+                );
             }
             _ => {}
         }
     });
-    assert_eq!(count, registered_spaces.len(), "must keep the exact number of registered spaces");
-    assert_eq!(all_spaces.len(), all_spaces_2.len(), "shouldn't change number of held spaces");
+    assert_eq!(
+        count,
+        registered_spaces.len(),
+        "must keep the exact number of registered spaces"
+    );
+    assert_eq!(
+        all_spaces.len(),
+        all_spaces_2.len(),
+        "shouldn't change number of held spaces"
+    );
 
     Ok(())
 }
@@ -281,20 +401,28 @@ async fn it_should_allow_applying_script_in_batch(rig: &TestRig) -> anyhow::Resu
     rig.wait_until_wallet_synced(ALICE).await?;
     rig.wait_until_synced().await?;
     let all_spaces = rig.spaced.client.wallet_list_spaces(ALICE).await?;
-    let registered_spaces: Vec<_> = all_spaces.iter().filter_map(|s| {
-        let space = s.space.as_ref().expect("space");
-        match space.covenant {
-            Covenant::Transfer { .. } => Some(space.name.to_string()),
-            _ => None,
-        }
-    }).collect();
+    let registered_spaces: Vec<_> = all_spaces
+        .iter()
+        .filter_map(|s| {
+            let space = s.space.as_ref().expect("space");
+            match space.covenant {
+                Covenant::Transfer { .. } => Some(space.name.to_string()),
+                _ => None,
+            }
+        })
+        .collect();
 
-    let result = wallet_do(rig, ALICE, vec![
-        RpcWalletRequest::Execute(ExecuteParams {
+    let result = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Execute(ExecuteParams {
             context: registered_spaces.clone(),
             space_script: SpaceScript::create_set_fallback(&[0xDE, 0xAD, 0xBE, 0xEF]),
-        }),
-    ], false).await.expect("send request");
+        })],
+        false,
+    )
+    .await
+    .expect("send request");
 
     println!("{}", serde_json::to_string_pretty(&result).unwrap());
 
@@ -311,162 +439,228 @@ async fn it_should_allow_applying_script_in_batch(rig: &TestRig) -> anyhow::Resu
     all_spaces_2.iter().for_each(|s| {
         let space = s.space.as_ref().expect("space");
         match &space.covenant {
-            Covenant::Transfer { expire_height, data } => {
+            Covenant::Transfer {
+                expire_height,
+                data,
+            } => {
                 count += 1;
-                assert_eq!(*expire_height, expected_expire_height, "must refresh expire height");
+                assert_eq!(
+                    *expire_height, expected_expire_height,
+                    "must refresh expire height"
+                );
                 assert!(data.is_some(), "must be data set");
-                assert_eq!(data.clone().unwrap().to_vec(), vec![0xDE, 0xAD, 0xBE, 0xEF], "must set correct data");
+                assert_eq!(
+                    data.clone().unwrap().to_vec(),
+                    vec![0xDE, 0xAD, 0xBE, 0xEF],
+                    "must set correct data"
+                );
             }
             _ => {}
         }
     });
-    assert_eq!(count, registered_spaces.len(), "must keep the exact number of registered spaces");
-    assert_eq!(all_spaces.len(), all_spaces_2.len(), "shouldn't change number of held spaces");
+    assert_eq!(
+        count,
+        registered_spaces.len(),
+        "must keep the exact number of registered spaces"
+    );
+    assert_eq!(
+        all_spaces.len(),
+        all_spaces_2.len(),
+        "shouldn't change number of held spaces"
+    );
 
     Ok(())
 }
-
-
 
 // Alice places an unconfirmed bid on @test2.
 // Bob attempts to replace it but fails due to a lack of confirmed bid & funding utxos.
 // Eve, with confirmed bid outputs/funds, successfully replaces the bid.
 async fn it_should_replace_mempool_bids(rig: &TestRig) -> anyhow::Result<()> {
     // create some confirmed bid outs for Eve
-    rig.spaced.client.wallet_send_request(
-        EVE,
-        RpcWalletTxBuilder {
-            bidouts: Some(2),
-            requests: vec![],
-            fee_rate: Some(FeeRate::from_sat_per_vb(2).expect("fee")),
-            dust: None,
-            force: false,
-            confirmed_only: false,
-            skip_tx_check: false,
-        },
-    ).await?;
+    rig.spaced
+        .client
+        .wallet_send_request(
+            EVE,
+            RpcWalletTxBuilder {
+                bidouts: Some(2),
+                requests: vec![],
+                fee_rate: Some(FeeRate::from_sat_per_vb(2).expect("fee")),
+                dust: None,
+                force: false,
+                confirmed_only: false,
+                skip_tx_check: false,
+            },
+        )
+        .await?;
     rig.mine_blocks(1, None).await?;
 
     rig.wait_until_wallet_synced(ALICE).await?;
     rig.wait_until_wallet_synced(BOB).await?;
     rig.wait_until_wallet_synced(EVE).await?;
 
-    let response = wallet_do(rig, ALICE, vec![
-        RpcWalletRequest::Bid(BidParams {
+    let response = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Bid(BidParams {
             name: "@test2".to_string(),
             amount: 1000,
-        })], false).await?;
+        })],
+        false,
+    )
+    .await?;
 
     let response = serde_json::to_string_pretty(&response).unwrap();
     println!("{}", response);
 
-    let response = wallet_do(rig, BOB, vec![
-        RpcWalletRequest::Bid(BidParams {
-            name: "@test2".to_string(),
-            amount: 1000,
-        })], false).await?;
-
-    let response = serde_json::to_string_pretty(&response).unwrap();
-
-    println!("{}", response);
-
-    assert!(response.contains("hint"), "should have a hint about replacement errors");
-
-    let replacement = rig.spaced.client.wallet_send_request(
+    let response = wallet_do(
+        rig,
         BOB,
-        RpcWalletTxBuilder {
-            bidouts: None,
-            requests: vec![
-                RpcWalletRequest::Bid(BidParams {
+        vec![RpcWalletRequest::Bid(BidParams {
+            name: "@test2".to_string(),
+            amount: 1000,
+        })],
+        false,
+    )
+    .await?;
+
+    let response = serde_json::to_string_pretty(&response).unwrap();
+
+    println!("{}", response);
+
+    assert!(
+        response.contains("hint"),
+        "should have a hint about replacement errors"
+    );
+
+    let replacement = rig
+        .spaced
+        .client
+        .wallet_send_request(
+            BOB,
+            RpcWalletTxBuilder {
+                bidouts: None,
+                requests: vec![RpcWalletRequest::Bid(BidParams {
                     name: "@test2".to_string(),
                     amount: 1000,
                 })],
-            fee_rate: Some(FeeRate::from_sat_per_vb(2).expect("fee")),
-            dust: None,
-            force: false,
-            confirmed_only: false,
-            skip_tx_check: false,
-        },
-    ).await?;
+                fee_rate: Some(FeeRate::from_sat_per_vb(2).expect("fee")),
+                dust: None,
+                force: false,
+                confirmed_only: false,
+                skip_tx_check: false,
+            },
+        )
+        .await?;
 
     let response = serde_json::to_string_pretty(&replacement).unwrap();
     println!("{}", response);
 
-    assert!(response.contains("hint"), "should have a hint about confirmed only");
-    assert!(response.contains("replacement-adds-unconfirmed"), "expected a replacement-adds-unconfirmed in the message");
+    assert!(
+        response.contains("hint"),
+        "should have a hint about confirmed only"
+    );
+    assert!(
+        response.contains("replacement-adds-unconfirmed"),
+        "expected a replacement-adds-unconfirmed in the message"
+    );
 
     // now let Eve try a replacement since she has confirmed outputs
-    let replacement = rig.spaced.client.wallet_send_request(
-        EVE,
-        RpcWalletTxBuilder {
-            bidouts: None,
-            requests: vec![
-                RpcWalletRequest::Bid(BidParams {
+    let replacement = rig
+        .spaced
+        .client
+        .wallet_send_request(
+            EVE,
+            RpcWalletTxBuilder {
+                bidouts: None,
+                requests: vec![RpcWalletRequest::Bid(BidParams {
                     name: "@test2".to_string(),
                     amount: 1000,
                 })],
-            fee_rate: Some(FeeRate::from_sat_per_vb(2).expect("fee")),
-            dust: None,
-            force: false,
-            confirmed_only: false,
-            skip_tx_check: false,
-        },
-    ).await?;
+                fee_rate: Some(FeeRate::from_sat_per_vb(2).expect("fee")),
+                dust: None,
+                force: false,
+                confirmed_only: false,
+                skip_tx_check: false,
+            },
+        )
+        .await?;
 
     let response = serde_json::to_string_pretty(&replacement).unwrap();
     println!("{}", response);
 
     for tx_res in replacement.result {
-        assert!(tx_res.error.is_none(), "Eve should have no problem replacing")
+        assert!(
+            tx_res.error.is_none(),
+            "Eve should have no problem replacing"
+        )
     }
 
     // Alice won't be able to build off other transactions from the double spent bid
     // even when Eve bid gets confirmed. Wallet must remove double spent tx.
     rig.mine_blocks(1, None).await?;
     rig.wait_until_wallet_synced(ALICE).await?;
-    let txs = rig.spaced.client.wallet_list_transactions(
-        ALICE,
-        1000, 0
-    ).await?;
-    let unconfirmed : Vec<_> = txs.iter().filter(|tx| !tx.confirmed).collect();
-    assert_eq!(unconfirmed.len(), 0, "there should be no stuck unconfirmed transactions");
+    let txs = rig
+        .spaced
+        .client
+        .wallet_list_transactions(ALICE, 1000, 0)
+        .await?;
+    let unconfirmed: Vec<_> = txs.iter().filter(|tx| !tx.confirmed).collect();
+    assert_eq!(
+        unconfirmed.len(),
+        0,
+        "there should be no stuck unconfirmed transactions"
+    );
     Ok(())
 }
 
 async fn it_should_maintain_locktime_when_fee_bumping(rig: &TestRig) -> anyhow::Result<()> {
     rig.wait_until_wallet_synced(ALICE).await?;
 
-    let response = rig.spaced.client.wallet_send_request(
-        ALICE,
-        RpcWalletTxBuilder {
-            bidouts: Some(2),
-            requests: vec![],
-            fee_rate: Some(FeeRate::from_sat_per_vb(1).expect("fee")),
-            dust: None,
-            force: false,
-            confirmed_only: false,
-            skip_tx_check: false
-        },
-    ).await?;
+    let response = rig
+        .spaced
+        .client
+        .wallet_send_request(
+            ALICE,
+            RpcWalletTxBuilder {
+                bidouts: Some(2),
+                requests: vec![],
+                fee_rate: Some(FeeRate::from_sat_per_vb(1).expect("fee")),
+                dust: None,
+                force: false,
+                confirmed_only: false,
+                skip_tx_check: false,
+            },
+        )
+        .await?;
 
-    println!("{}",  serde_json::to_string_pretty(&response).unwrap());
+    println!("{}", serde_json::to_string_pretty(&response).unwrap());
 
     let txid = response.result[0].txid;
-    for tx_res in response.result{
+    for tx_res in response.result {
         assert!(tx_res.error.is_none(), "should not be error");
     }
 
     let tx = rig.get_raw_transaction(&txid).await?;
 
-    let bump = rig.spaced.client.wallet_bump_fee(
-        ALICE, txid, FeeRate::from_sat_per_vb(4).expect("fee"), false
-    ).await?;
+    let bump = rig
+        .spaced
+        .client
+        .wallet_bump_fee(
+            ALICE,
+            txid,
+            FeeRate::from_sat_per_vb(4).expect("fee"),
+            false,
+        )
+        .await?;
     assert_eq!(bump.len(), 1, "should only be 1 tx");
     assert!(bump[0].error.is_none(), "should be no errors");
 
     let replacement = rig.get_raw_transaction(&bump[0].txid).await?;
 
-    assert_eq!(tx.lock_time, replacement.lock_time, "locktimes must not change");
+    assert_eq!(
+        tx.lock_time, replacement.lock_time,
+        "locktimes must not change"
+    );
     Ok(())
 }
 
@@ -495,19 +689,28 @@ async fn run_auction_tests() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn wallet_do(rig: &TestRig, wallet: &str, requests: Vec<RpcWalletRequest>, force: bool) -> anyhow::Result<WalletResponse> {
-    let res = rig.spaced.client.wallet_send_request(
-        wallet,
-        RpcWalletTxBuilder {
-            bidouts: None,
-            requests,
-            fee_rate: Some(FeeRate::from_sat_per_vb(1).expect("fee")),
-            dust: None,
-            force,
-            confirmed_only: false,
-            skip_tx_check: false,
-        },
-    ).await?;
+async fn wallet_do(
+    rig: &TestRig,
+    wallet: &str,
+    requests: Vec<RpcWalletRequest>,
+    force: bool,
+) -> anyhow::Result<WalletResponse> {
+    let res = rig
+        .spaced
+        .client
+        .wallet_send_request(
+            wallet,
+            RpcWalletTxBuilder {
+                bidouts: None,
+                requests,
+                fee_rate: Some(FeeRate::from_sat_per_vb(1).expect("fee")),
+                dust: None,
+                force,
+                confirmed_only: false,
+                skip_tx_check: false,
+            },
+        )
+        .await?;
     Ok(res)
 }
 

--- a/testutil/build.rs
+++ b/testutil/build.rs
@@ -1,12 +1,12 @@
-use std::env;
-use std::fs;
-use std::path::Path;
-use std::io;
+use std::{env, fs, io, path::Path};
 
 fn main() -> io::Result<()> {
     let zip_path = Path::new("testdata/regtest.zip");
     if !zip_path.exists() {
-        return Err(io::Error::new(io::ErrorKind::NotFound, "no regtest testdata found in testdata/regtest.zip"));
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "no regtest testdata found in testdata/regtest.zip",
+        ));
     }
     let out_dir = env::var("OUT_DIR").unwrap();
     let target_dir = Path::new(&out_dir).join("regtest_unpacked");

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -1,8 +1,13 @@
 pub extern crate bitcoind;
 pub mod spaced;
 
-use std::{fs, io, sync::Arc, time::Duration};
-use std::path::{Path, PathBuf};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
 use ::spaced::{
     jsonrpsee::tokio,
     node::protocol::{
@@ -19,15 +24,15 @@ use ::spaced::{
 use anyhow::Result;
 use bitcoind::{
     anyhow,
-    anyhow::anyhow,
+    anyhow::{anyhow, Context},
     bitcoincore_rpc::{
         bitcoincore_rpc_json::{GetBlockTemplateModes, GetBlockTemplateRules},
         RpcApi,
     },
+    tempfile::{tempdir, TempDir},
     BitcoinD,
 };
-use bitcoind::anyhow::Context;
-use bitcoind::tempfile::{tempdir, TempDir};
+
 use crate::spaced::SpaceD;
 
 // Path to the pre-created regtest testdata in build.rs
@@ -47,8 +52,8 @@ pub struct TestRig {
 
 impl TestRig {
     pub async fn new_with_regtest_preset() -> Result<TestRig> {
-        let original_test_data = bitcoin_regtest_data_path()
-            .context("could not get unpacked regtest testdata")?;
+        let original_test_data =
+            bitcoin_regtest_data_path().context("could not get unpacked regtest testdata")?;
         let test_data = tempdir()?;
         copy_dir_all(original_test_data, test_data.path())?;
 
@@ -66,8 +71,11 @@ impl TestRig {
     }
 
     pub async fn testdata_wallets_path(&self) -> PathBuf {
-        self.test_data.as_ref().expect("created with regtest preset")
-            .path().join("wallets")
+        self.test_data
+            .as_ref()
+            .expect("created with regtest preset")
+            .path()
+            .join("wallets")
     }
 
     pub async fn new() -> Result<TestRig> {
@@ -84,7 +92,10 @@ impl TestRig {
         Self::new_with_bitcoin_conf(conf, None).await
     }
 
-    pub async fn new_with_bitcoin_conf(conf: bitcoind::Conf<'static>, test_data: Option<TempDir>) -> Result<Self> {
+    pub async fn new_with_bitcoin_conf(
+        conf: bitcoind::Conf<'static>,
+        test_data: Option<TempDir>,
+    ) -> Result<Self> {
         let view_stdout = conf.view_stdout;
         let bitcoind =
             tokio::task::spawn_blocking(move || BitcoinD::from_downloaded_with_conf(&conf))
@@ -204,8 +215,8 @@ impl TestRig {
                 &[],
             )
         })
-            .await
-            .expect("handle")?;
+        .await
+        .expect("handle")?;
 
         let txdata = vec![Transaction {
             version: transaction::Version::ONE,
@@ -376,8 +387,8 @@ impl TestRig {
             c.client
                 .send_to_address(&addr, amount, None, None, None, None, None, None)
         })
-            .await
-            .expect("handle")?;
+        .await
+        .expect("handle")?;
         Ok(txid)
     }
 }

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -161,6 +161,7 @@ impl TestRig {
 
     /// Waits until named wallet tip == bitcoind tip
     pub async fn wait_until_wallet_synced(&self, wallet_name: &str) -> anyhow::Result<()> {
+        self.wait_until_synced().await?;
         loop {
             let c = self.bitcoind.clone();
             let count = tokio::task::spawn_blocking(move || c.client.get_block_count())

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-
+use std::collections::HashMap;
 use ::spaced::{
     jsonrpsee::tokio,
     node::protocol::{
@@ -32,7 +32,7 @@ use bitcoind::{
     tempfile::{tempdir, TempDir},
     BitcoinD,
 };
-
+use bitcoind::bitcoincore_rpc::json;
 use crate::spaced::SpaceD;
 
 // Path to the pre-created regtest testdata in build.rs
@@ -334,6 +334,25 @@ impl TestRig {
         let txid = txid.clone();
         Ok(
             tokio::task::spawn_blocking(move || c.client.get_raw_transaction(&txid, None))
+                .await
+                .expect("handle")?,
+        )
+    }
+
+    pub async fn get_raw_mempool(&self) -> Result<HashMap<Txid, json::GetMempoolEntryResult>> {
+        let c = self.bitcoind.clone();
+        Ok(
+            tokio::task::spawn_blocking(move || c.client.get_raw_mempool_verbose())
+                .await
+                .expect("handle")?,
+        )
+    }
+
+    pub async fn get_block(&self, hash: &BlockHash) -> Result<Block> {
+        let c = self.bitcoind.clone();
+        let hash = hash.clone();
+        Ok(
+            tokio::task::spawn_blocking(move || c.client.get_block(&hash))
                 .await
                 .expect("handle")?,
         )

--- a/testutil/src/spaced.rs
+++ b/testutil/src/spaced.rs
@@ -1,5 +1,9 @@
-use std::{net::Ipv4Addr, process::Child, time::Duration};
-use std::process::Stdio;
+use std::{
+    net::Ipv4Addr,
+    process::{Child, Stdio},
+    time::Duration,
+};
+
 use anyhow::Result;
 use assert_cmd::cargo::CommandCargoExt;
 use bitcoind::{anyhow, anyhow::anyhow, get_available_port, tempfile::tempdir};

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 bitcoin = { version = "0.32.2", features = ["base64", "serde"] }
-bdk_wallet = { version = "1.0.0-beta.6", features = ["keys-bip39", "rusqlite"] }
+# bdk version 1.0.0-beta.6 + hard coded patch for double spend fix from PR https://github.com/bitcoindevkit/bdk/pull/1765
+bdk_wallet = { git = "https://github.com/buffrr/bdk.git", rev= "43bca8643dec6fdda99e4a29bf88709729af349e", features = ["keys-bip39", "rusqlite"] }
 secp256k1 = "0.29.0"
 anyhow = "1.0.80"
 bech32 = "0.11.0"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bitcoin = { version = "0.32.2", features = ["base64", "serde"] }
-bdk_wallet = { version = "1.0.0-beta.5", features = ["keys-bip39", "rusqlite"] }
+bdk_wallet = { version = "1.0.0-beta.6", features = ["keys-bip39", "rusqlite"] }
 secp256k1 = "0.29.0"
 anyhow = "1.0.80"
 bech32 = "0.11.0"
@@ -17,3 +17,7 @@ protocol = { path = "../protocol", features = ["std"], version = "*" }
 ctrlc = "3.4.4"
 hex = "0.4.3"
 log = "0.4.21"
+
+
+[dev-dependencies]
+tempfile = "3.14.0"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 
 [dependencies]
 bitcoin = { version = "0.32.2", features = ["base64", "serde"] }
-bdk_wallet = { version = "=1.0.0-alpha.13", features = ["keys-bip39"] }
-bdk_file_store = "0.13.0"
+bdk_wallet = { version = "1.0.0-beta.5", features = ["keys-bip39", "rusqlite"] }
 secp256k1 = "0.29.0"
 anyhow = "1.0.80"
 bech32 = "0.11.0"

--- a/wallet/src/builder.rs
+++ b/wallet/src/builder.rs
@@ -711,28 +711,30 @@ impl Builder {
                     _ => counts,
                 });
 
-        let required_auction_outputs = open_count + bid_count as u8;
-        let available = if required_auction_outputs > 0 {
+        let required_bidouts = open_count + bid_count as u8;
+        let available = if required_bidouts > 0 {
             wallet.list_bidouts(false)?
         } else {
             Vec::new()
         };
 
+        // Always create a few more bidouts for future transactions
+        const EXTRA_BIDOUTS : u8 = 2;
         // check how many bid outputs we need to create
         let auction_outputs = match self.bidouts {
             None => {
-                if required_auction_outputs > available.len() as u8 {
-                    Some(required_auction_outputs - available.len() as u8)
+                if required_bidouts > available.len() as u8 {
+                    Some((required_bidouts - available.len() as u8) + EXTRA_BIDOUTS)
                 } else {
                     None
                 }
             }
             Some(count) => {
-                if required_auction_outputs > available.len() as u8 + count {
+                if required_bidouts > available.len() as u8 + count {
                     return Err(anyhow!(
-                        "number of required placeholders {} \
+                        "number of required bidouts {} \
                     exceeds currently available {} + requested {}",
-                        required_auction_outputs,
+                        required_bidouts,
                         available.len(),
                         count
                     ));

--- a/wallet/src/builder.rs
+++ b/wallet/src/builder.rs
@@ -954,7 +954,7 @@ impl CoinSelectionAlgorithm for SpacesAwareCoinSelection {
         required_utxos: Vec<WeightedUtxo>,
         mut optional_utxos: Vec<WeightedUtxo>,
         fee_rate: FeeRate,
-        target_amount: u64,
+        target_amount: Amount,
         drain_script: &Script,
         rand: &mut R,
     ) -> Result<CoinSelectionResult, InsufficientFunds> {
@@ -968,7 +968,7 @@ impl CoinSelectionAlgorithm for SpacesAwareCoinSelection {
             if self.confirmed_only {
                 match &weighted_utxo.utxo {
                     Utxo::Local(local) => {
-                        if !local.confirmation_time.is_confirmed() {
+                        if !local.chain_position.is_confirmed() {
                             return false;
                         }
                     }

--- a/wallet/src/builder.rs
+++ b/wallet/src/builder.rs
@@ -10,14 +10,17 @@ use anyhow::{anyhow, Context};
 use bdk_wallet::{
     coin_selection::{
         CoinSelectionAlgorithm, CoinSelectionResult, DefaultCoinSelectionAlgorithm,
+        InsufficientFunds,
     },
     error::CreateTxError,
     tx_builder::TxOrdering,
     KeychainKind, TxBuilder, Utxo, WeightedUtxo,
 };
-use bdk_wallet::coin_selection::InsufficientFunds;
-use bitcoin::{absolute::LockTime, psbt, psbt::Input, script, script::PushBytesBuf, Address, Amount, FeeRate, Network, OutPoint, Psbt, Script, ScriptBuf, Sequence, Transaction, TxOut, Txid, Weight, Witness};
-use bitcoin::key::rand::RngCore;
+use bitcoin::{
+    absolute::LockTime, key::rand::RngCore, psbt::Input, script, script::PushBytesBuf, Address,
+    Amount, FeeRate, Network, OutPoint, Psbt, Script, ScriptBuf, Sequence, Transaction, TxOut,
+    Txid, Weight, Witness,
+};
 use protocol::{
     bitcoin::absolute::Height,
     constants::{BID_PSBT_INPUT_SEQUENCE, BID_PSBT_TX_VERSION},
@@ -170,8 +173,8 @@ trait TxBuilderSpacesUtils<'a, Cs: CoinSelectionAlgorithm> {
 }
 
 fn tap_key_spend_weight() -> Weight {
-    let tap_key_spend_weight : u64 = 66;
-     Weight::from_vb(tap_key_spend_weight).expect("valid weight")
+    let tap_key_spend_weight: u64 = 66;
+    Weight::from_vb(tap_key_spend_weight).expect("valid weight")
 }
 
 impl<'a, Cs: CoinSelectionAlgorithm> TxBuilderSpacesUtils<'a, Cs> for TxBuilder<'a, Cs> {
@@ -234,7 +237,7 @@ impl<'a, Cs: CoinSelectionAlgorithm> TxBuilderSpacesUtils<'a, Cs> for TxBuilder<
             placeholder.auction.outpoint.vout as u8,
             &offer,
         )?)
-            .expect("compressed psbt script bytes");
+        .expect("compressed psbt script bytes");
 
         let carrier = ScriptBuf::new_op_return(&compressed_psbt);
 
@@ -290,12 +293,10 @@ impl<'a, Cs: CoinSelectionAlgorithm> TxBuilderSpacesUtils<'a, Cs> for TxBuilder<
                         .mul(2),
                 );
 
-                self.add_utxo(
-                    OutPoint {
-                        txid: request.space.txid,
-                        vout: request.space.spaceout.n as u32,
-                    }
-                )?;
+                self.add_utxo(OutPoint {
+                    txid: request.space.txid,
+                    vout: request.space.spaceout.n as u32,
+                })?;
 
                 self.add_recipient(
                     request.recipient.script_pubkey(),
@@ -966,9 +967,9 @@ impl CoinSelectionAlgorithm for SpacesAwareCoinSelection {
 
             weighted_utxo.utxo.txout().value > SpacesAwareCoinSelection::DUST_THRESHOLD
                 && !self
-                .exclude_outputs
-                .iter()
-                .any(|o| o.outpoint == weighted_utxo.utxo.outpoint())
+                    .exclude_outputs
+                    .iter()
+                    .any(|o| o.outpoint == weighted_utxo.utxo.outpoint())
         });
 
         let mut result = self.default_algorithm.coin_select(
@@ -977,7 +978,7 @@ impl CoinSelectionAlgorithm for SpacesAwareCoinSelection {
             fee_rate,
             target_amount,
             drain_script,
-            rand
+            rand,
         )?;
 
         let mut optional = Vec::with_capacity(result.selected.len() - required.len());

--- a/wallet/src/builder.rs
+++ b/wallet/src/builder.rs
@@ -240,7 +240,7 @@ impl<'a, Cs: CoinSelectionAlgorithm> TxBuilderSpacesUtils<'a, Cs> for TxBuilder<
             placeholder.auction.outpoint.vout as u8,
             &offer,
         )?)
-        .expect("compressed psbt script bytes");
+            .expect("compressed psbt script bytes");
 
         let carrier = ScriptBuf::new_op_return(&compressed_psbt);
 
@@ -464,7 +464,7 @@ impl Iterator for BuilderIterator<'_> {
                         return Some(Err(signing_info.unwrap_err()));
                     }
                     reveals.push(signing_info.unwrap());
-                    contexts.push( execute.context);
+                    contexts.push(execute.context);
                 }
 
                 let (tx, commitments) = match Builder::prepare_all(
@@ -476,7 +476,7 @@ impl Iterator for BuilderIterator<'_> {
                     params.sends.clone(),
                     self.fee_rate,
                     self.dust,
-                    self.confirmed_only
+                    self.confirmed_only,
                 ) {
                     Ok(prep) => prep,
                     Err(err) => return Some(Err(err)),
@@ -540,7 +540,7 @@ impl Iterator for BuilderIterator<'_> {
                             signing,
                             commitment,
                         },
-                        context
+                        context,
                     }))
                 }
 
@@ -591,7 +591,7 @@ impl Iterator for BuilderIterator<'_> {
                     for space in spaces {
                         detailed.add_execute(
                             space.space.spaceout.space.expect("space").name.to_string(),
-                            reveal_input_index
+                            reveal_input_index,
                         );
                     }
                     detailed
@@ -608,7 +608,7 @@ impl Iterator for BuilderIterator<'_> {
                 );
                 Some(tx.map(|tx| {
                     let mut detailed = TxRecord::new(tx);
-                    detailed.add_bid(&bid.space, bid.amount);
+                    detailed.add_bid(self.wallet, &bid.space, bid.amount);
                     detailed
                 }))
             }
@@ -683,13 +683,13 @@ impl Builder {
         self
     }
 
-    pub fn build_iter<'a>(
+    pub fn build_iter(
         self,
         dust: Option<Amount>,
         median_time: u64,
-        wallet: &'a mut SpacesWallet,
+        wallet: &mut SpacesWallet,
         confirmed_only: bool,
-    ) -> anyhow::Result<BuilderIterator<'a>> {
+    ) -> anyhow::Result<BuilderIterator> {
         let fee_rate = self
             .fee_rate
             .as_ref()
@@ -978,9 +978,9 @@ impl CoinSelectionAlgorithm for SpacesAwareCoinSelection {
 
             weighted_utxo.utxo.txout().value > SpacesAwareCoinSelection::DUST_THRESHOLD
                 && !self
-                    .exclude_outputs
-                    .iter()
-                    .any(|o| o.outpoint == weighted_utxo.utxo.outpoint())
+                .exclude_outputs
+                .iter()
+                .any(|o| o.outpoint == weighted_utxo.utxo.outpoint())
         });
 
         let mut result = self.default_algorithm.coin_select(

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -41,7 +41,7 @@ pub mod tx_event;
 pub struct SpacesWallet {
     pub config: WalletConfig,
     internal: PersistedWallet<Connection>,
-    connection: Connection,
+    pub connection: Connection,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -405,6 +405,11 @@ impl SpacesWallet {
         let txid = tx_record.tx.compute_txid();
         self.apply_unconfirmed_tx(tx_record.tx, seen);
 
+        // Insert txouts for foreign inputs to be able to calculate fees
+        for (outpoint, txout) in tx_record.txouts {
+            self.internal.insert_txout(outpoint, txout);
+        }
+
         let db_tx = self.connection.transaction()
             .context("could not create wallet db transaction")?;
         for event in tx_record.events {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -273,6 +273,11 @@ impl SpacesWallet {
         self.internal.list_output()
     }
 
+    pub fn list_watched_spaces(&mut self) -> anyhow::Result<Vec<String>> {
+        let db_tx = self.connection.transaction().context("no db transaction")?;
+        TxEvent::watched_spaces(&db_tx).context("could not read watched spaces")
+    }
+
     pub fn list_unspent_with_details(&mut self, store: &mut impl DataSource) -> anyhow::Result<Vec<WalletOutput>> {
         let mut wallet_outputs = Vec::new();
         for output in self.internal.list_unspent() {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -153,6 +153,7 @@ impl SpacesWallet {
                 .check_network(config.network)
                 .descriptor(KeychainKind::External, Some(config.space_descriptors.external.clone()))
                 .descriptor(KeychainKind::Internal, Some(config.space_descriptors.internal.clone()))
+                .lookahead(50)
                 .extract_keys()
             .load_wallet(&mut conn).context("could not load wallet")? {
             wallet
@@ -161,6 +162,7 @@ impl SpacesWallet {
                 config.space_descriptors.external.clone(),
                 config.space_descriptors.internal.clone(),
             )
+                .lookahead(50)
                 .network(config.network)
                 .genesis_hash(genesis_hash)
                 .create_wallet(&mut conn).context("could not create wallet")?

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -194,6 +194,10 @@ impl SpacesWallet {
         self.internal.get_tx(txid)
     }
 
+    pub fn get_utxo(&mut self, outpoint: OutPoint) -> Option<LocalOutput> {
+        self.internal.get_utxo(outpoint)
+    }
+
     pub fn build_tx(&mut self, confirmed_only: bool)
                     -> anyhow::Result<TxBuilder<SpacesAwareCoinSelection>> {
         self.create_builder(None, confirmed_only)

--- a/wallet/src/rusqlite_impl.rs
+++ b/wallet/src/rusqlite_impl.rs
@@ -1,0 +1,119 @@
+use std::str::FromStr;
+
+// Simple schema migration adapted from bdk to include
+// additional metadata stored alongside bdk's tables
+// https://github.com/bitcoindevkit/bdk/blob/bcff89d51d0e1d91058e4430eda8cc57fb7f0f08/crates/chain/src/rusqlite_impl.rs#L55
+use bdk_wallet::rusqlite;
+use bdk_wallet::rusqlite::{
+    named_params,
+    types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef},
+    OptionalExtension, ToSql, Transaction,
+};
+
+use crate::*;
+
+/// Table name for schemas.
+pub const SCHEMAS_TABLE_NAME: &str = "spaces_schemas";
+pub struct Impl<T>(pub T);
+
+/// Initialize the schema table.
+fn init_schemas_table(db_tx: &Transaction) -> rusqlite::Result<()> {
+    let sql = format!("CREATE TABLE IF NOT EXISTS {}( name TEXT PRIMARY KEY NOT NULL, version INTEGER NOT NULL ) STRICT", SCHEMAS_TABLE_NAME);
+    db_tx.execute(&sql, ())?;
+    Ok(())
+}
+
+/// Get schema version of `schema_name`.
+fn schema_version(db_tx: &Transaction, schema_name: &str) -> rusqlite::Result<Option<u32>> {
+    let sql = format!(
+        "SELECT version FROM {} WHERE name=:name",
+        SCHEMAS_TABLE_NAME
+    );
+    db_tx
+        .query_row(&sql, named_params! { ":name": schema_name }, |row| {
+            row.get::<_, u32>("version")
+        })
+        .optional()
+}
+
+/// Set the `schema_version` of `schema_name`.
+fn set_schema_version(
+    db_tx: &Transaction,
+    schema_name: &str,
+    schema_version: u32,
+) -> rusqlite::Result<()> {
+    let sql = format!(
+        "REPLACE INTO {}(name, version) VALUES(:name, :version)",
+        SCHEMAS_TABLE_NAME,
+    );
+    db_tx.execute(
+        &sql,
+        named_params! { ":name": schema_name, ":version": schema_version },
+    )?;
+    Ok(())
+}
+
+/// Runs logic that initializes/migrates the table schemas.
+pub fn migrate_schema(
+    db_tx: &Transaction,
+    schema_name: &str,
+    versioned_scripts: &[&[&str]],
+) -> rusqlite::Result<()> {
+    init_schemas_table(db_tx)?;
+    let current_version = schema_version(db_tx, schema_name)?;
+    let exec_from = current_version.map_or(0_usize, |v| v as usize + 1);
+    let scripts_to_exec = versioned_scripts.iter().enumerate().skip(exec_from);
+    for (version, &script) in scripts_to_exec {
+        set_schema_version(db_tx, schema_name, version as u32)?;
+        for statement in script {
+            db_tx.execute(statement, ())?;
+        }
+    }
+    Ok(())
+}
+
+impl FromSql for Impl<bitcoin::OutPoint> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        bitcoin::OutPoint::from_str(value.as_str()?)
+            .map(Self)
+            .map_err(from_sql_error)
+    }
+}
+
+impl ToSql for Impl<bitcoin::OutPoint> {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(self.0.to_string().into())
+    }
+}
+
+impl FromSql for Impl<Txid> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        Txid::from_str(value.as_str()?)
+            .map(Self)
+            .map_err(from_sql_error)
+    }
+}
+
+impl ToSql for Impl<Txid> {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(self.0.to_string().into())
+    }
+}
+
+impl FromSql for Impl<serde_json::Value> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        serde_json::Value::from_str(value.as_str()?)
+            .map(Self)
+            .map_err(from_sql_error)
+    }
+}
+
+impl ToSql for Impl<serde_json::Value> {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(self.0.to_string().into())
+    }
+}
+
+fn from_sql_error<E: std::error::Error + Send + Sync + 'static>(err: E) -> FromSqlError {
+    FromSqlError::Other(Box::new(err))
+}

--- a/wallet/src/tx_event.rs
+++ b/wallet/src/tx_event.rs
@@ -198,7 +198,9 @@ impl TxEvent {
         let query = format!(
             "SELECT DISTINCT space
          FROM {}
-         WHERE type = 'bid' AND space IS NOT NULL AND created_at >= strftime('%s', 'now', '-14 days')",
+         WHERE type IN ('bid', 'open')
+         AND space IS NOT NULL
+         AND created_at >= strftime('%s', 'now', '-14 days')",
             Self::TX_EVENTS_TABLE_NAME,
         );
 

--- a/wallet/src/tx_event.rs
+++ b/wallet/src/tx_event.rs
@@ -1,0 +1,459 @@
+use std::{fmt, fmt::Display, str::FromStr};
+
+use bdk_wallet::{
+    chain, rusqlite,
+    rusqlite::{
+        types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef},
+        ToSql,
+    },
+};
+use bitcoin::{Amount, OutPoint, ScriptBuf, Transaction, Txid};
+use serde::{Deserialize, Serialize};
+use protocol::{Covenant, FullSpaceOut};
+use crate::rusqlite_impl::{migrate_schema, Impl};
+
+#[derive(Clone, Debug)]
+pub struct TxRecord {
+    pub tx: Transaction,
+    pub events: Vec<TxEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxEvent {
+    #[serde(rename = "type")]
+    pub kind: TxEventKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub space: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bid_spends: Option<OutPoint>,
+    pub replaced: bool,
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub details: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BidEventDetails {
+    pub bid_current: Amount,
+    pub bid_previous: Amount,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TransferEventDetails {
+    pub to: ScriptBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BidoutEventDetails {
+    pub count: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SendEventDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_space: Option<String>,
+    pub resolved_address: ScriptBuf,
+    pub amount: Amount,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OpenEventDetails {
+    pub bid_initial: Amount,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CommitEventDetails {
+    pub reveal_script_pubkey: protocol::Bytes,
+    /// [SpaceScriptSigningInfo] in raw format
+    pub reveal_signing_info: protocol::Bytes,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExecuteEventDetails {
+    pub space_script_input_index: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TxEventKind {
+    Commit,
+    Bidout,
+    Open,
+    Script,
+    Bid,
+    Register,
+    Transfer,
+    Send,
+    FeeBump
+}
+
+impl TxEvent {
+    pub const TX_EVENTS_TABLE_NAME: &'static str = "spaces_tx_events";
+    pub const TX_EVENTS_SCHEMA_NAME: &'static str = "spaces_tx_events_schema";
+
+    pub fn init_sqlite_tables(db_tx: &chain::rusqlite::Transaction) -> chain::rusqlite::Result<()> {
+        let schema_v0: &[&str] = &[&format!(
+            "CREATE TABLE {} ( \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                txid TEXT NOT NULL, \
+                type TEXT NOT NULL, \
+                space TEXT, \
+                bid_spends TEXT, \
+                replaced INTEGER DEFAULT 0, \
+                details TEXT \
+            ) STRICT;",
+            Self::TX_EVENTS_TABLE_NAME,
+        )];
+
+        migrate_schema(db_tx, Self::TX_EVENTS_SCHEMA_NAME, &[schema_v0])
+    }
+
+    pub fn all(db_tx: &rusqlite::Transaction, txid: Txid) -> rusqlite::Result<Vec<Self>> {
+        let stmt = db_tx.prepare(&format!(
+            "SELECT type, space, bid_spends, replaced, details
+         FROM {} WHERE txid = ?1",
+            Self::TX_EVENTS_TABLE_NAME,
+        ))?;
+        Self::from_sqlite_statement(stmt, [Impl(txid)])
+    }
+
+    pub fn bids(db_tx: &rusqlite::Transaction, space: String) -> rusqlite::Result<Vec<Self>> {
+        let stmt = db_tx.prepare(&format!(
+            "SELECT type, space, bid_spends, replaced, details
+         FROM {} WHERE type = 'bid' AND space = ?1",
+            Self::TX_EVENTS_TABLE_NAME,
+        ))?;
+        Self::from_sqlite_statement(stmt, [space])
+    }
+
+    pub fn spaces(db_tx: &rusqlite::Transaction) -> rusqlite::Result<Vec<String>> {
+        let query = format!(
+            "SELECT DISTINCT space
+         FROM {}
+         WHERE type = 'bid' AND space IS NOT NULL",
+            Self::TX_EVENTS_TABLE_NAME,
+        );
+
+        let mut stmt = db_tx.prepare(&query)?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+
+        let mut spaces = Vec::new();
+        for space in rows {
+            spaces.push(space?);
+        }
+        Ok(spaces)
+    }
+
+    fn from_sqlite_statement<P: rusqlite::Params>(
+        mut stmt: rusqlite::Statement,
+        params: P,
+    ) -> rusqlite::Result<Vec<Self>> {
+        let row_iter = stmt.query_map(params, |row| {
+            Ok((
+                row.get::<_, TxEventKind>("type")?,
+                row.get::<_, Option<String>>("space")?,
+                row.get::<_, Option<Impl<OutPoint>>>("bid_spends")?,
+                row.get::<_, bool>("replaced")?,
+                row.get::<_, Option<Impl<serde_json::Value>>>("details")?,
+            ))
+        })?;
+
+        let mut events = Vec::new();
+        for row in row_iter {
+            let (event_type, space, bid_spends, replaced, details) = row?;
+            events.push(TxEvent {
+                kind: event_type,
+                space,
+                bid_spends: bid_spends.map(|x| x.0),
+                replaced,
+                details: details.map(|x| x.0),
+            })
+        }
+
+        Ok(events)
+    }
+
+    pub fn insert(
+        db_tx: &rusqlite::Transaction,
+        txid: Txid,
+        kind: TxEventKind,
+        space: Option<String>,
+        bid_spends: Option<OutPoint>,
+        replaced: bool,
+        details: Option<serde_json::Value>,
+    ) -> rusqlite::Result<usize> {
+        let query = format!(
+            "INSERT INTO {} (txid, type, space, bid_spends, replaced, details)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            Self::TX_EVENTS_TABLE_NAME,
+        );
+
+        db_tx.execute(
+            &query,
+            rusqlite::params![
+                txid.to_string(),
+                kind,
+                space,
+                bid_spends.map(|b| b.to_string()),
+                replaced as i32,
+                details.map(|d| d.to_string())
+            ],
+        )?;
+
+        Ok(db_tx.last_insert_rowid() as usize)
+    }
+}
+
+
+impl TxRecord {
+    pub fn new(tx: Transaction) -> Self {
+        Self {
+            events: Vec::new(),
+            tx,
+        }
+    }
+
+    pub fn new_with_events(tx: Transaction, events: Vec<TxEvent>) -> Self {
+        Self {
+            events,
+            tx,
+        }
+    }
+
+    pub fn add_fee_bump(&mut self) {
+        self.events.push(TxEvent {
+            kind: TxEventKind::FeeBump,
+            space: None,
+            bid_spends: None,
+            replaced: false,
+            details: None,
+        });
+    }
+
+    pub fn add_transfer(&mut self, space: String, to: ScriptBuf) {
+        self.events.push(TxEvent {
+            kind: TxEventKind::Transfer,
+            space: Some(space),
+            bid_spends: None,
+            replaced: false,
+            details: Some(serde_json::to_value(TransferEventDetails { to }).expect("json value")),
+        });
+    }
+
+    pub fn add_bidout(&mut self, count: usize) {
+        self.events.push(TxEvent {
+            kind: TxEventKind::Bidout,
+            space: None,
+            bid_spends: None,
+            replaced: false,
+            details: Some(serde_json::to_value(BidoutEventDetails { count }).expect("json value")),
+        });
+    }
+
+    pub fn add_send(
+        &mut self,
+        amount: Amount,
+        to_space: Option<String>,
+        resolved_address: ScriptBuf,
+    ) {
+        self.events.push(TxEvent {
+            kind: TxEventKind::Send,
+            space: None,
+            bid_spends: None,
+            replaced: false,
+            details: Some(
+                serde_json::to_value(SendEventDetails {
+                    to_space,
+                    resolved_address,
+                    amount,
+                })
+                    .expect("json value"),
+            ),
+        });
+    }
+
+    // Should be added for every space affected by this commitment
+    pub fn add_commitment(
+        &mut self,
+        space: String,
+        reveal_address: ScriptBuf,
+        signing_info: Vec<u8>,
+    ) {
+        self.events.push(TxEvent {
+            kind: TxEventKind::Commit,
+            space: Some(space),
+            bid_spends: None,
+            replaced: false,
+            details: Some(
+                serde_json::to_value(CommitEventDetails {
+                    reveal_script_pubkey: protocol::Bytes::new(reveal_address.to_bytes()),
+                    reveal_signing_info: protocol::Bytes::new(signing_info),
+                })
+                    .expect("json value"),
+            ),
+        });
+    }
+
+    pub fn add_open(&mut self, space: String, initial_bid: Amount) {
+        self.events.push(TxEvent {
+            kind: TxEventKind::Open,
+            space: Some(space),
+            bid_spends: None,
+            replaced: false,
+            details: Some(
+                serde_json::to_value(OpenEventDetails {
+                    bid_initial: initial_bid,
+                })
+                    .expect("json value"),
+            ),
+        });
+    }
+
+    // Should be added for each space affected
+    pub fn add_execute(&mut self, space: String, reveal_input_index: usize) {
+        self.events.push(TxEvent {
+            kind: TxEventKind::Script,
+            space: Some(space),
+            bid_spends: None,
+            replaced: false,
+            details: Some(
+                serde_json::to_value(ExecuteEventDetails {
+                    space_script_input_index: reveal_input_index,
+                })
+                    .expect("json value"),
+            ),
+        });
+    }
+
+    pub fn add_bid(&mut self, previous: &FullSpaceOut, amount: Amount) {
+        let space = previous.spaceout.space.as_ref().expect("space not found");
+        let previous_bid = match space.covenant {
+            Covenant::Bid { total_burned, .. } => total_burned,
+            _ => panic!("expected a bid"),
+        };
+        self.events.push(TxEvent {
+            kind: TxEventKind::Bid,
+            space: Some(space.name.to_string()),
+            bid_spends: None,
+            replaced: false,
+            details: Some(
+                serde_json::to_value(BidEventDetails {
+                    bid_current: amount,
+                    bid_previous: previous_bid,
+                })
+                    .expect("json value"),
+            ),
+        });
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{hashes::Hash, Txid};
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use crate::{tx_event::TxEventKind, *};
+
+    #[test]
+    fn test_tx_event() -> anyhow::Result<()> {
+        // Create a temporary directory
+        let tmp_dir = tempdir()?;
+        let db_path = tmp_dir.path().join("test.db");
+
+        // Initialize SQLite connection
+        let mut conn = Connection::open(&db_path)?;
+        let tx = conn.transaction()?;
+
+        // Initialize the table
+        TxEvent::init_sqlite_tables(&tx)?;
+
+        // Insert a sample transaction event
+        let txid = Txid::all_zeros();
+        let kind = TxEventKind::Bid;
+        let space = Some("test_space".to_string());
+        let details = Some(json!({"amount": 1000, "currency": "USD"}));
+
+        TxEvent::insert(&tx, txid, kind, space.clone(), None, true, details.clone())?;
+
+        // Commit the transaction
+        tx.commit()?;
+
+        // Re-open the connection to verify the insertion
+        let mut conn = Connection::open(&db_path)?;
+        let tx = conn.transaction()?;
+
+        // Query the inserted event
+        let inserted_events = TxEvent::all(&tx, txid)?;
+
+        assert_eq!(inserted_events.len(), 1);
+        let event = &inserted_events[0];
+        assert_eq!(event.space, space);
+        assert_eq!(event.replaced, true);
+        assert_eq!(event.details, details);
+
+        let mut conn = Connection::open(&db_path)?;
+        let tx = conn.transaction()?;
+
+        let spaces = TxEvent::spaces(&tx)?;
+        assert_eq!(spaces.len(), 1);
+        assert_eq!(spaces[0], "test_space");
+
+        let bids = TxEvent::bids(&tx, "test_space".to_string())?;
+        assert_eq!(bids.len(), 1);
+        assert!(matches!(bids[0].kind, TxEventKind::Bid));
+
+        Ok(())
+    }
+}
+
+impl Display for TxEventKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            TxEventKind::Commit => "commit",
+            TxEventKind::Bidout => "bidout",
+            TxEventKind::Open => "open",
+            TxEventKind::Bid => "bid",
+            TxEventKind::Register => "register",
+            TxEventKind::Transfer => "transfer",
+            TxEventKind::Send => "send",
+            TxEventKind::Script => "script",
+            TxEventKind::FeeBump => "fee-bump"
+        })
+    }
+}
+
+impl FromStr for TxEventKind {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "commit" => Ok(TxEventKind::Commit),
+            "bidout" => Ok(TxEventKind::Bidout),
+            "open" => Ok(TxEventKind::Open),
+            "bid" => Ok(TxEventKind::Bid),
+            "register" => Ok(TxEventKind::Register),
+            "transfer" => Ok(TxEventKind::Transfer),
+            "send" => Ok(TxEventKind::Send),
+            "script" => Ok(TxEventKind::Script),
+            "fee-bump" => Ok(TxEventKind::FeeBump),
+            _ => Err("invalid event kind"),
+        }
+    }
+}
+
+impl FromSql for TxEventKind {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        value
+            .as_str()
+            .map_err(|_| FromSqlError::InvalidType)?
+            .parse()
+            .map_err(|_| FromSqlError::InvalidType)
+    }
+}
+
+impl ToSql for TxEventKind {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(self.to_string()))
+    }
+}


### PR DESCRIPTION
This a large PR as it changes the wallet persistence and touches many parts of the codebase. Changes include:

1. Switch to the sqlite backend for better stability
2. Store additional metadata about a transaction such as which tx is a bid, open, transfer ... etc
3. Watch the mempool for bid replacements to free up locked funds without having to wait for confirmation
4. `listspaces` now shows which spaces have been outbid
5. Use a batched version of bdk to handle issues with conflicting bid transactions
6. Update bdk to the most recent stable version
7. Graceful RPC retries 
8. Create extra bidouts to save on tx fees
9. Add wallet sync checks to make sure spaces and wallet tips are up to date 
10. Several other bug fixes and stability imporvements.

Fixes #53 
Fixes #54
Fixes #45
