### PR TITLE
Marketplace Listings API: buy, sell and verify listings

### DIFF
--- a/node/src/bin/space-cli.rs
+++ b/node/src/bin/space-cli.rs
@@ -681,7 +681,7 @@ async fn handle_commands(
                 .wallet_sell(
                     &cli.wallet,
                     space,
-                    Amount::from_sat(price),
+                    price,
                 ).await?;
             println!("{}", serde_json::to_string_pretty(&result).expect("result"));
         }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -199,7 +199,7 @@ pub trait Rpc {
         &self,
         wallet: &str,
         space: String,
-        amount: Amount,
+        amount: u64,
     ) -> Result<Listing, ErrorObjectOwned>;
 
     #[method(name = "verifylisting")]
@@ -789,7 +789,7 @@ impl RpcServer for RpcServerImpl {
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
     }
 
-    async fn wallet_sell(&self, wallet: &str, space: String, amount: Amount) -> Result<Listing, ErrorObjectOwned> {
+    async fn wallet_sell(&self, wallet: &str, space: String, amount: u64) -> Result<Listing, ErrorObjectOwned> {
         self.wallet(&wallet)
             .await?
             .send_sell(space, amount)

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -35,7 +35,7 @@ use tokio::{
     sync::{broadcast, mpsc, oneshot, RwLock},
     task::JoinSet,
 };
-use wallet::{bdk_wallet as bdk, bdk_wallet::template::Bip86, bitcoin::hashes::Hash, export::WalletExport, Balance, DoubleUtxo, WalletConfig, WalletDescriptors, WalletInfo, WalletOutput};
+use wallet::{bdk_wallet as bdk, bdk_wallet::template::Bip86, bitcoin::hashes::Hash, export::WalletExport, Balance, DoubleUtxo, Listing, SpacesWallet, WalletConfig, WalletDescriptors, WalletInfo, WalletOutput};
 
 use crate::{
     checker::TxChecker,
@@ -94,6 +94,10 @@ pub enum ChainStateCommand {
     GetRollout {
         target: usize,
         resp: Responder<anyhow::Result<Vec<RolloutEntry>>>,
+    },
+    VerifyListing {
+        listing: Listing,
+        resp: Responder<anyhow::Result<()>>,
     },
 }
 
@@ -181,6 +185,29 @@ pub trait Rpc {
         skip_tx_check: bool,
     ) -> Result<Vec<TxResponse>, ErrorObjectOwned>;
 
+    #[method(name = "walletbuy")]
+    async fn wallet_buy(
+        &self,
+        wallet: &str,
+        listing: Listing,
+        fee_rate: Option<FeeRate>,
+        skip_tx_check: bool,
+    ) -> Result<TxResponse, ErrorObjectOwned>;
+
+    #[method(name = "walletsell")]
+    async fn wallet_sell(
+        &self,
+        wallet: &str,
+        space: String,
+        amount: Amount,
+    ) -> Result<Listing, ErrorObjectOwned>;
+
+    #[method(name = "verifylisting")]
+    async fn verify_listing(
+        &self,
+        listing: Listing,
+    ) -> Result<(), ErrorObjectOwned>;
+
     #[method(name = "walletlisttransactions")]
     async fn wallet_list_transactions(
         &self,
@@ -199,7 +226,7 @@ pub trait Rpc {
 
     #[method(name = "walletlistspaces")]
     async fn wallet_list_spaces(&self, wallet: &str)
-        -> Result<ListSpacesResponse, ErrorObjectOwned>;
+                                -> Result<ListSpacesResponse, ErrorObjectOwned>;
 
     #[method(name = "walletlistunspent")]
     async fn wallet_list_unspent(
@@ -754,6 +781,29 @@ impl RpcServer for RpcServerImpl {
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
     }
 
+    async fn wallet_buy(&self, wallet: &str, listing: Listing, fee_rate: Option<FeeRate>, skip_tx_check: bool) -> Result<TxResponse, ErrorObjectOwned> {
+        self.wallet(&wallet)
+            .await?
+            .send_buy(listing, fee_rate, skip_tx_check)
+            .await
+            .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
+    }
+
+    async fn wallet_sell(&self, wallet: &str, space: String, amount: Amount) -> Result<Listing, ErrorObjectOwned> {
+        self.wallet(&wallet)
+            .await?
+            .send_sell(space, amount)
+            .await
+            .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
+    }
+
+    async fn verify_listing(&self, listing: Listing) -> Result<(), ErrorObjectOwned> {
+        self.store
+            .verify_listing(listing)
+            .await
+            .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
+    }
+
     async fn wallet_list_transactions(
         &self,
         wallet: &str,
@@ -953,6 +1003,9 @@ impl AsyncChainState {
                 let rollouts = chain_state.get_rollout(target);
                 _ = resp.send(rollouts);
             }
+            ChainStateCommand::VerifyListing { listing, resp } => {
+                _ = resp.send(SpacesWallet::verify_listing::<Sha256>(chain_state, &listing).map(|_| ()));
+            }
         }
     }
 
@@ -982,6 +1035,14 @@ impl AsyncChainState {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
             .send(ChainStateCommand::EstimateBid { target, resp })
+            .await?;
+        resp_rx.await?
+    }
+
+    pub async fn verify_listing(&self, listing: Listing) -> anyhow::Result<()> {
+        let (resp, resp_rx) = oneshot::channel();
+        self.sender
+            .send(ChainStateCommand::VerifyListing { listing, resp })
             .await?;
         resp_rx.await?
     }

--- a/node/src/wallets.rs
+++ b/node/src/wallets.rs
@@ -18,7 +18,7 @@ use tokio::time::Instant;
 use wallet::{address::SpaceAddress, bdk_wallet::{
     chain::{local_chain::CheckPoint, BlockId},
     KeychainKind,
-}, bitcoin, bitcoin::{Address, Amount, FeeRate, OutPoint}, builder::{CoinTransfer, SpaceTransfer, SpacesAwareCoinSelection}, tx_event::{TxRecord, TxEvent, TxEventKind}, Balance, DoubleUtxo, SpacesWallet, WalletInfo, WalletOutput};
+}, bitcoin, bitcoin::{Address, Amount, FeeRate, OutPoint}, builder::{CoinTransfer, SpaceTransfer, SpacesAwareCoinSelection}, tx_event::{TxRecord, TxEvent, TxEventKind}, Balance, DoubleUtxo, Listing, SpacesWallet, WalletInfo, WalletOutput};
 use crate::{checker::TxChecker, config::ExtendedNetwork, node::BlockSource, rpc::{RpcWalletRequest, RpcWalletTxBuilder, WalletLoadRequest}, source::{
     BitcoinBlockSource, BitcoinRpc, BitcoinRpcError, BlockEvent, BlockFetchError, BlockFetcher,
 }, std_wait, store::{ChainState, LiveSnapshot, Sha256}};
@@ -85,6 +85,17 @@ pub enum WalletCommand {
     ListSpaces {
         resp: crate::rpc::Responder<anyhow::Result<ListSpacesResponse>>,
     },
+    Buy {
+        listing: Listing,
+        skip_tx_check: bool,
+        fee_rate: Option<FeeRate>,
+        resp: crate::rpc::Responder<anyhow::Result<TxResponse>>,
+    },
+    Sell {
+        space: String,
+        price: Amount,
+        resp: crate::rpc::Responder<anyhow::Result<Listing>>,
+    },
     ListBidouts {
         resp: crate::rpc::Responder<anyhow::Result<Vec<DoubleUtxo>>>,
     },
@@ -143,6 +154,60 @@ impl RpcWallet {
         }
 
         None
+    }
+
+    fn handle_buy(
+        source: &BitcoinBlockSource,
+        state: &mut LiveSnapshot,
+        wallet: &mut SpacesWallet,
+        listing: Listing,
+        skip_tx_check: bool,
+        fee_rate: Option<FeeRate>,
+    ) -> anyhow::Result<TxResponse> {
+        let fee_rate = match fee_rate.as_ref() {
+            None => match Self::estimate_fee_rate(source) {
+                None => return Err(anyhow!("could not estimate fee rate")),
+                Some(r) => r,
+            },
+            Some(r) => r.clone(),
+        };
+        info!("Using fee rate: {} sat/vB", fee_rate.to_sat_per_vb_ceil());
+
+        let (_, fullspaceout) = SpacesWallet::verify_listing::<Sha256>(state, &listing)?;
+
+        let space = fullspaceout.spaceout.space.as_ref().expect("space").name.to_string();
+        let foreign_input = fullspaceout.outpoint();
+        let tx = wallet.buy::<Sha256>(state, &listing, fee_rate)?;
+        
+        if !skip_tx_check {
+            let tip = wallet.local_chain().tip().height();
+            let mut checker = TxChecker::new(state);
+            checker.check_apply_tx(tip + 1, &tx)?;
+        }
+
+        let new_txid = tx.compute_txid();
+        let last_seen = source.rpc.broadcast_tx(&source.client, &tx)?;
+
+        let tx_record = TxRecord::new_with_events(tx, vec![TxEvent {
+            kind: TxEventKind::Buy,
+            space: Some(space),
+            foreign_input: Some(foreign_input),
+            details: None,
+        }]);
+
+        let events = tx_record.events.clone();
+
+        // Incrementing last_seen by 1 ensures eviction of older tx
+        // in cases with same-second/last seen replacement.
+        wallet.apply_unconfirmed_tx_record(tx_record, last_seen+1)?;
+        wallet.commit()?;
+
+        Ok(TxResponse {
+            txid: new_txid,
+            events,
+            error: None,
+            raw: None,
+        })
     }
 
     fn handle_fee_bump(
@@ -303,6 +368,12 @@ impl RpcWallet {
             }
             WalletCommand::UnloadWallet => {
                 info!("Unloading wallet '{}' ...", wallet.name());
+            }
+            WalletCommand::Buy { listing, resp, skip_tx_check, fee_rate } => {
+                _ = resp.send(Self::handle_buy(source, state, wallet, listing, skip_tx_check, fee_rate));
+            }
+            WalletCommand::Sell { space, price, resp } => {
+                _ = resp.send(wallet.sell::<Sha256>(state, &space, price));
             }
         }
         Ok(())
@@ -1070,6 +1141,40 @@ impl RpcWallet {
         resp_rx.await?
     }
 
+    pub async fn send_buy(
+        &self,
+        listing: Listing,
+        fee_rate: Option<FeeRate>,
+        skip_tx_check: bool,
+    ) -> anyhow::Result<TxResponse> {
+        let (resp, resp_rx) = oneshot::channel();
+        self.sender
+            .send(WalletCommand::Buy {
+                listing,
+                fee_rate,
+                skip_tx_check,
+                resp,
+            })
+            .await?;
+        resp_rx.await?
+    }
+
+    pub async fn send_sell(
+        &self,
+        space: String,
+        price: Amount,
+    ) -> anyhow::Result<Listing> {
+        let (resp, resp_rx) = oneshot::channel();
+        self.sender
+            .send(WalletCommand::Sell {
+                space,
+                resp,
+                price,
+            })
+            .await?;
+        resp_rx.await?
+    }
+
     pub async fn send_list_transactions(
         &self,
         count: usize,
@@ -1081,6 +1186,8 @@ impl RpcWallet {
             .await?;
         resp_rx.await?
     }
+
+
 
     pub async fn send_force_spend(
         &self,

--- a/node/src/wallets.rs
+++ b/node/src/wallets.rs
@@ -93,7 +93,7 @@ pub enum WalletCommand {
     },
     Sell {
         space: String,
-        price: Amount,
+        price: u64,
         resp: crate::rpc::Responder<anyhow::Result<Listing>>,
     },
     ListBidouts {
@@ -373,7 +373,7 @@ impl RpcWallet {
                 _ = resp.send(Self::handle_buy(source, state, wallet, listing, skip_tx_check, fee_rate));
             }
             WalletCommand::Sell { space, price, resp } => {
-                _ = resp.send(wallet.sell::<Sha256>(state, &space, price));
+                _ = resp.send(wallet.sell::<Sha256>(state, &space, Amount::from_sat(price)));
             }
         }
         Ok(())
@@ -1162,7 +1162,7 @@ impl RpcWallet {
     pub async fn send_sell(
         &self,
         space: String,
-        price: Amount,
+        price: u64,
     ) -> anyhow::Result<Listing> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender

--- a/node/tests/integration_tests.rs
+++ b/node/tests/integration_tests.rs
@@ -991,7 +991,7 @@ async fn it_should_allow_buy_sell(rig: &TestRig) -> anyhow::Result<()> {
     let space = alice_spaces.owned.first().expect("alice should have at least 1 space");
 
     let space_name = space.spaceout.space.as_ref().unwrap().name.to_string();
-    let listing = rig.spaced.client.wallet_sell(ALICE, space_name.clone(), Amount::from_sat(5000)).await.expect("sell");
+    let listing = rig.spaced.client.wallet_sell(ALICE, space_name.clone(), 5000).await.expect("sell");
 
     println!("listing\n{}", serde_json::to_string_pretty(&listing).unwrap());
 

--- a/wallet/src/builder.rs
+++ b/wallet/src/builder.rs
@@ -176,7 +176,7 @@ trait TxBuilderSpacesUtils<'a, Cs: CoinSelectionAlgorithm> {
     fn add_send(&mut self, request: CoinTransfer) -> anyhow::Result<&mut Self>;
 }
 
-fn tap_key_spend_weight() -> Weight {
+pub fn tap_key_spend_weight() -> Weight {
     let tap_key_spend_weight: u64 = 66;
     Weight::from_vb(tap_key_spend_weight).expect("valid weight")
 }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -61,7 +61,7 @@ pub struct Balance {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Listing {
     pub space: String,
-    pub price: Amount,
+    pub price: u64,
     pub seller: String,
     pub signature: schnorr::Signature,
 }
@@ -619,7 +619,7 @@ impl SpacesWallet {
                 )?
                 .add_recipient(
                     seller.script_pubkey(),
-                    spaceout.spaceout.value + listing.price,
+                    spaceout.spaceout.value + Amount::from_sat(listing.price),
                 )
                 .add_recipient(space_address.script_pubkey(), dust_amount);
             builder.finish()?
@@ -661,7 +661,7 @@ impl SpacesWallet {
         let prevouts = Prevouts::One(0, txout.clone());
         let addr = SpaceAddress::from_str(&listing.seller)?;
 
-        let total = listing.price + txout.value;
+        let total = Amount::from_sat(listing.price) + txout.value;
         let mut tx = bitcoin::blockdata::transaction::Transaction {
             version: Version(2),
             lock_time: BID_PSBT_TX_LOCK_TIME,
@@ -756,7 +756,7 @@ impl SpacesWallet {
 
         Ok(Listing {
             space: space.to_string(),
-            price: asking_price,
+            price: asking_price.to_sat(),
             seller: recipient.to_string(),
             signature: Signature::from_slice(&signature[..64])
                 .expect("signed listing has a valid signature"),

--- a/wallet/src/tx_event.rs
+++ b/wallet/src/tx_event.rs
@@ -85,6 +85,7 @@ pub enum TxEventKind {
     Transfer,
     Send,
     FeeBump,
+    Buy,
 }
 
 impl TxEvent {
@@ -505,7 +506,8 @@ impl Display for TxEventKind {
             TxEventKind::Transfer => "transfer",
             TxEventKind::Send => "send",
             TxEventKind::Script => "script",
-            TxEventKind::FeeBump => "fee-bump"
+            TxEventKind::FeeBump => "fee-bump",
+            TxEventKind::Buy => "buy"
         })
     }
 }


### PR DESCRIPTION
This PR adds a `walletbuy`, `walletsell` and `verifylisting` RPC commands, and a standarized format for marketplace listings. This is simpler than having to deal directly with PSBTs and more human readable.


The listings look like this and can be verified using the `verifylisting` rpc call.

```json
{
  "space": "@example",
  "price": 5000,
  "seller": "tbs1p6ly5949g3ga3x8sv2fgc7d8x2cs024sqw94yp7nh0nf788teqh3qrza2x6",
  "signature": "48e3d431e7fcbd7f04db5e96999665072484098fff8790dc596f64813f6d04545148218173497863d747920426ca688f9e8b82b9e5ac5ef08d9e22b2e9b8b3ac"
}
``` 


Using space-cli, selling a space is as simple as:

```
$ space-cli sell @example 5000
```

Buying a space 

```
$ space-cli buy @example 5000 --seller <address> --signature <signature>
```

These listings are completely trustless!