### PR TITLE
Add Renew command

### DIFF
--- a/node/src/bin/space-cli.rs
+++ b/node/src/bin/space-cli.rs
@@ -133,6 +133,16 @@ enum Commands {
         #[arg(long, short)]
         fee_rate: Option<u64>,
     },
+    /// Renew ownership of a space
+    #[command(name = "renew", )]
+    Renew {
+        /// Spaces to renew
+        #[arg(display_order = 0)]
+        spaces: Vec<String>,
+        /// Fee rate to use in sat/vB
+        #[arg(long, short)]
+        fee_rate: Option<u64>,
+    },
     /// Estimates the minimum bid needed for a rollout within the given target blocks
     #[command(name = "estimatebid")]
     EstimateBid {
@@ -554,6 +564,19 @@ async fn handle_commands(
             )
                 .await?
         }
+        Commands::Renew { spaces, fee_rate } => {
+            let spaces: Vec<_> = spaces.into_iter().map(|s| normalize_space(&s)).collect();
+            cli.send_request(
+                Some(RpcWalletRequest::Transfer(TransferSpacesParams {
+                    spaces,
+                    to: None,
+                })),
+                None,
+                fee_rate,
+                false,
+            )
+                .await?
+        }
         Commands::Transfer {
             spaces,
             to,
@@ -563,7 +586,7 @@ async fn handle_commands(
             cli.send_request(
                 Some(RpcWalletRequest::Transfer(TransferSpacesParams {
                     spaces,
-                    to,
+                    to: Some(to),
                 })),
                 None,
                 fee_rate,
@@ -741,6 +764,7 @@ async fn handle_commands(
             }).await?;
             println!("{}", serde_json::to_string_pretty(&result).expect("result"));
         }
+
     }
 
     Ok(())

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -273,16 +273,18 @@ pub enum RpcWalletRequest {
     Register(RegisterParams),
     #[serde(rename = "execute")]
     Execute(ExecuteParams),
-    #[serde(rename = "sendspaces")]
+    #[serde(rename = "transfer")]
     Transfer(TransferSpacesParams),
-    #[serde(rename = "sendcoins")]
+    #[serde(rename = "send")]
     SendCoins(SendCoinsParams),
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct TransferSpacesParams {
     pub spaces: Vec<String>,
-    pub to: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/node/tests/integration_tests.rs
+++ b/node/tests/integration_tests.rs
@@ -364,7 +364,7 @@ async fn it_should_allow_batch_transfers_refreshing_expire_height(
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
             spaces: registered_spaces.clone(),
-            to: space_address,
+            to: Some(space_address),
         })],
         false,
     )
@@ -781,7 +781,7 @@ async fn it_should_not_allow_register_or_transfer_to_same_space_multiple_times(r
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
             spaces: vec![transfer.clone()],
-            to: bob_address.clone(),
+            to: Some(bob_address.clone()),
         })],
         false,
     ).await.expect("send request");
@@ -792,7 +792,7 @@ async fn it_should_not_allow_register_or_transfer_to_same_space_multiple_times(r
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
             spaces: vec![transfer],
-            to: bob_address,
+            to: Some(bob_address),
         })],
         false,
     ).await.expect_err("there's already a transfer submitted");
@@ -849,7 +849,7 @@ async fn it_can_batch_txs(rig: &TestRig) -> anyhow::Result<()> {
         vec![
             RpcWalletRequest::Transfer(TransferSpacesParams {
                 spaces: vec!["@test9996".to_string()],
-                to: bob_address,
+                to: Some(bob_address),
             }),
             RpcWalletRequest::Bid(BidParams {
                 name: "@test100".to_string(),

--- a/wallet/src/builder.rs
+++ b/wallet/src/builder.rs
@@ -119,7 +119,7 @@ pub struct RegisterRequest {
 #[derive(Debug, Clone)]
 pub struct SpaceTransfer {
     pub space: FullSpaceOut,
-    pub recipient: Address,
+    pub recipient: SpaceAddress,
 }
 
 #[derive(Debug, Clone)]
@@ -555,17 +555,31 @@ impl Iterator for BuilderIterator<'_> {
                 if !params.transfers.is_empty() {
                     // TODO: resolved address recipient
                     for transfer in &params.transfers {
-                        detailed_tx.add_transfer(
-                            transfer
-                                .space
-                                .spaceout
-                                .space
-                                .as_ref()
-                                .expect("space")
-                                .name
-                                .to_string(),
-                            transfer.recipient.script_pubkey(),
-                        );
+                        if self.wallet.is_mine(transfer.recipient.script_pubkey()) {
+                            detailed_tx.add_renew(
+                                transfer
+                                    .space
+                                    .spaceout
+                                    .space
+                                    .as_ref()
+                                    .expect("space")
+                                    .name
+                                    .to_string(),
+                                transfer.recipient.script_pubkey(),
+                            );
+                        } else {
+                            detailed_tx.add_transfer(
+                                transfer
+                                    .space
+                                    .spaceout
+                                    .space
+                                    .as_ref()
+                                    .expect("space")
+                                    .name
+                                    .to_string(),
+                                transfer.recipient.script_pubkey(),
+                            );
+                        }
                     }
                 }
                 if !params.sends.is_empty() {
@@ -783,7 +797,7 @@ impl Builder {
                     };
                     transfers.push(SpaceTransfer {
                         space: params.space,
-                        recipient: to.0,
+                        recipient: to,
                     })
                 }
                 StackRequest::Send(send) => sends.push(send),

--- a/wallet/src/tx_event.rs
+++ b/wallet/src/tx_event.rs
@@ -83,6 +83,7 @@ pub enum TxEventKind {
     Bid,
     Register,
     Transfer,
+    Renew,
     Send,
     FeeBump,
     Buy,
@@ -322,6 +323,15 @@ impl TxRecord {
         });
     }
 
+    pub fn add_renew(&mut self, space: String, to: ScriptBuf) {
+        self.events.push(TxEvent {
+            kind: TxEventKind::Renew,
+            space: Some(space),
+            foreign_input: None,
+            details: Some(serde_json::to_value(TransferEventDetails { to }).expect("json value")),
+        });
+    }
+
     pub fn add_bidout(&mut self, count: usize) {
         self.events.push(TxEvent {
             kind: TxEventKind::Bidout,
@@ -507,7 +517,8 @@ impl Display for TxEventKind {
             TxEventKind::Send => "send",
             TxEventKind::Script => "script",
             TxEventKind::FeeBump => "fee-bump",
-            TxEventKind::Buy => "buy"
+            TxEventKind::Buy => "buy",
+            TxEventKind::Renew => "renew",
         })
     }
 }
@@ -527,6 +538,7 @@ impl FromStr for TxEventKind {
             "script" => Ok(TxEventKind::Script),
             "fee-bump" => Ok(TxEventKind::FeeBump),
             "buy" => Ok(TxEventKind::Buy),
+            "renew" => Ok(TxEventKind::Renew),
             _ => Err("invalid event kind"),
         }
     }


### PR DESCRIPTION
This PR:

- Makes the recipient field optional for transfers through RPC re-using the same script pubkey if not specified.
- Add a renew command to the wallet

Renewals "move" the space with changing any details so that messages signed with `signmessage` will remain valid. Of course, users can still rotate their keys by using the transfer command.


Using space-cli, you can renew like this:

```
space-cli renew @bitcoin
```