### PR TITLE
New simplified output format for space-cli & bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -430,6 +430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,7 +531,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -539,6 +545,15 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -833,7 +848,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1303,7 +1318,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1536,6 +1551,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "papergrid"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,7 +1630,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1674,6 +1700,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit 0.21.1",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2127,7 +2175,7 @@ checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2267,6 +2315,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "clap",
+ "colored",
  "ctrlc",
  "directories",
  "env_logger",
@@ -2280,6 +2329,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spacedb",
+ "tabled",
  "testutil",
  "threadpool",
  "tokio",
@@ -2318,6 +2368,17 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
@@ -2332,6 +2393,29 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
+name = "tabled"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "tar"
@@ -2391,7 +2475,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2463,7 +2547,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2607,7 +2691,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2651,6 +2735,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "untrusted"
@@ -2758,7 +2848,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
@@ -2792,7 +2882,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3028,7 +3118,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -36,7 +36,8 @@ base64 = "0.22.1"
 futures = "0.3.30"
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 threadpool = "1.8.1"
-
+tabled = "0.17.0"
+colored = "3.0.0"
 [dev-dependencies]
 assert_cmd = "2.0.16"
 predicates = "3.1.2"

--- a/node/src/format.rs
+++ b/node/src/format.rs
@@ -1,0 +1,401 @@
+use clap::ValueEnum;
+use colored::{Color, Colorize};
+use jsonrpsee::core::Serialize;
+use serde::Deserialize;
+use tabled::{Table, Tabled};
+use protocol::bitcoin::{Amount, Network, OutPoint};
+use protocol::{Covenant};
+use wallet::address::SpaceAddress;
+use wallet::{Balance, DoubleUtxo, WalletInfo, WalletOutput};
+use wallet::bdk_wallet::KeychainKind;
+use wallet::bitcoin::{Address, Txid};
+use wallet::tx_event::{BidEventDetails, BidoutEventDetails, OpenEventDetails, SendEventDetails, TransferEventDetails, TxEventKind};
+use crate::rpc::ServerInfo;
+use crate::wallets::{ListSpacesResponse, TxInfo, TxResponse, WalletResponse};
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Format {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FormatRpcError {
+    code: i32,
+    message: String,
+}
+
+#[derive(Tabled)]
+#[tabled(rename_all = "UPPERCASE")]
+struct WinningSpaces {
+    space: String,
+    bid: u64,
+    #[tabled(rename = "CLAIM AT")]
+    claim_at: String,
+    #[tabled(rename = "DAYS LEFT")]
+    days_left: String,
+}
+
+#[derive(Tabled)]
+#[tabled(rename_all = "UPPERCASE")]
+struct OutbidSpaces {
+    space: String,
+    #[tabled(rename = "LAST CONFIRMED BID")]
+    last_confirmed_bid: u64,
+    #[tabled(rename = "DAYS LEFT")]
+    days_left: String,
+}
+
+#[derive(Tabled)]
+#[tabled(rename_all = "UPPERCASE")]
+struct RegisteredSpaces {
+    space: String,
+    #[tabled(rename = "EXPIRE AT")]
+    expire_at: usize,
+    #[tabled(rename = "DAYS LEFT")]
+    days_left: String,
+    #[tabled(rename = "UTXO")]
+    utxo: OutPoint
+}
+
+#[derive(Tabled)]
+#[tabled(rename_all = "UPPERCASE")]
+struct UnspentOutput {
+    outpoint: OutPoint,
+    value: Amount,
+    confirmed: bool,
+    external: bool,
+}
+
+#[derive(Tabled)]
+#[tabled(rename_all = "UPPERCASE")]
+struct Bidout {
+    txid: Txid,
+    vout_1: u32,
+    vout_2: u32,
+    confirmed: bool,
+}
+
+fn format_days_left(current_block: u32, claim_height: Option<u32>) -> String {
+    match claim_height {
+        Some(height) => {
+            let blocks_remaining = height as isize - current_block as isize;
+            let days_remaining = (blocks_remaining as f64 / 6.0 / 24.0).max(0.0);
+            format!("{:.2}", days_remaining)
+        }
+        None => "--".to_string(),
+    }
+}
+
+pub fn print_list_bidouts(bidouts: Vec<DoubleUtxo>, format: Format) {
+    match format {
+        Format::Text => {
+            let all : Vec<_> = bidouts.into_iter().map(|out| Bidout {
+                txid: out.spend.outpoint.txid,
+                vout_1: out.spend.outpoint.vout,
+                vout_2: out.auction.outpoint.vout,
+                confirmed: out.confirmed,
+            }).collect();
+            println!("{}", ascii_table(all));
+        }
+        Format::Json => {
+            println!("{}", serde_json::to_string_pretty(&bidouts).unwrap());
+
+        }
+    }
+}
+
+pub fn print_list_transactions(txs: Vec<TxInfo>, format: Format) {
+    match format {
+        Format::Text => {
+            println!("{}", ascii_table(txs));
+        }
+        Format::Json => {
+            println!("{}", serde_json::to_string_pretty(&txs).unwrap());
+        }
+    }
+}
+
+
+
+pub fn print_list_unspent(utxos: Vec<WalletOutput>, format: Format) {
+    match format {
+        Format::Text => {
+            let utxos : Vec<_> = utxos.iter().map(|utxo| UnspentOutput {
+                outpoint: utxo.output.outpoint,
+                confirmed: utxo.output.chain_position.is_confirmed(),
+                value: utxo.output.txout.value,
+                external: utxo.output.keychain == KeychainKind::External,
+            }).collect();
+            println!("{}", ascii_table(utxos))
+        }
+        Format::Json => {
+            println!("{}", serde_json::to_string_pretty(&utxos).unwrap());
+        }
+    }
+}
+
+pub fn print_server_info(info: ServerInfo, format: Format) {
+    match format {
+        Format::Text => {
+            println!("CHAIN: {}", info.chain);
+            println!("  Height {}", info.tip.height);
+            println!("  Hash {}", info.tip.hash);
+        }
+        Format::Json => {
+            println!("{}", serde_json::to_string_pretty(&info).unwrap());
+        }
+    }
+}
+
+pub fn print_wallet_info(info: WalletInfo, format: Format) {
+    match format {
+        Format::Text => {
+            println!("WALLET: {}", info.label);
+            println!("  Tip {}\n  Birthday {}",
+                     info.tip,
+                     info.start_block
+            );
+
+            println!("  Public descriptors");
+            for desc in info.descriptors {
+                println!("    {}", desc.descriptor);
+            }
+            println!();
+        }
+        Format::Json => {
+            println!("{}", serde_json::to_string_pretty(&info).unwrap());
+        }
+    }
+}
+
+fn ascii_table<I, T>(iter: I) -> String
+where
+    I: IntoIterator<Item = T>,
+    T: Tabled,
+{
+    Table::new(iter)
+        .with(tabled::settings::Style::modern_rounded())
+        .to_string()
+}
+
+pub fn print_wallet_balance_response(balance: Balance, format: Format) {
+    match format {
+        Format::Text => {
+            println!("Balance: {}", balance.balance.to_sat());
+            println!("  Confirmed         {:>14}", balance.details.balance.confirmed.to_sat());
+            println!("  Trusted pending   {:>14}", balance.details.balance.trusted_pending.to_sat());
+            println!("  Untrusted pending {:>14}", balance.details.balance.untrusted_pending.to_sat());
+            println!("  Dust & in-auction {:>14}", balance.details.dust.to_sat());
+        }
+        Format::Json => {
+            println!("{}", serde_json::to_string_pretty(&balance).unwrap());
+        }
+    }
+}
+
+pub fn print_list_spaces_response(current_block: u32, response: ListSpacesResponse, format: Format) {
+    match format {
+        Format::Text => {
+            let mut outbids = Vec::new();
+            let mut winnings = Vec::new();
+            let mut owned = Vec::new();
+            for res in response.outbid {
+                let space = res.spaceout.space.as_ref().expect("space");
+                let mut outbid = OutbidSpaces {
+                    space: space.name.to_string(),
+                    last_confirmed_bid: 0,
+                    days_left: "".to_string(),
+                };
+                match space.covenant {
+                    Covenant::Bid { total_burned, claim_height, .. } => {
+                        outbid.last_confirmed_bid = total_burned.to_sat();
+                        outbid.days_left = format_days_left(current_block, claim_height);
+                    }
+                    _ => {}
+                }
+                outbids.push(outbid);
+            }
+
+            for res in response.winning {
+                let space = res.spaceout.space.as_ref().expect("space");
+                let mut winning = WinningSpaces {
+                    space: space.name.to_string(),
+                    bid: 0,
+                    days_left: "--".to_string(),
+                    claim_at: "--".to_string(),
+                };
+                match space.covenant {
+                    Covenant::Bid { total_burned, claim_height, .. } => {
+                        winning.bid = total_burned.to_sat();
+                        winning.claim_at = claim_height.map(|h| h.to_string()).unwrap_or("--".to_string());
+                        winning.days_left = format_days_left(current_block, claim_height);
+                        if winning.days_left == "0.00" {
+                            winning.days_left = "Ready to claim".to_string();
+                        }
+                    }
+                    _ => {}
+                }
+                winnings.push(winning);
+            }
+            for res in response.owned {
+                let space = res.spaceout.space.as_ref().expect("space");
+                let mut registered = RegisteredSpaces {
+                    space: space.name.to_string(),
+                    expire_at: 0,
+                    days_left: "--".to_string(),
+                    utxo: res.outpoint(),
+                };
+                match &space.covenant {
+                    Covenant::Transfer { expire_height, .. } => {
+                        registered.expire_at = *expire_height as _;
+                        registered.days_left = format_days_left(current_block, Some(*expire_height));
+                    }
+                    _ => {}
+                }
+                owned.push(registered);
+            }
+
+
+            if !outbids.is_empty() {
+                println!("⚠️ OUTBID ({} spaces): ", outbids.len().to_string().bold());
+                let table = ascii_table(outbids);
+                println!("{}", table);
+            }
+
+            if !winnings.is_empty() {
+                println!("{} WINNING ({} spaces):","✓".color(Color::Green), winnings.len().to_string().bold());
+                let table = ascii_table(winnings);
+                println!("{}", table);
+            }
+
+            if !owned.is_empty() {
+                println!("{} ({} spaces): ", "🔑 OWNED", owned.len().to_string().bold());
+                let table = ascii_table(owned);
+                println!("{}", table);
+            }
+        }
+        Format::Json => println!("{}", serde_json::to_string_pretty(&response).unwrap()),
+    }
+}
+pub fn print_wallet_response(network: Network, response: WalletResponse, format: Format) {
+    match format {
+        Format::Text => print_wallet_response_text(network, response),
+        Format::Json => println!("{}", serde_json::to_string_pretty(&response).unwrap()),
+    }
+}
+
+pub fn print_wallet_response_text(network: Network, response: WalletResponse) {
+    let mut main_txs = Vec::new();
+    let mut secondary_txs = Vec::new();
+
+    for tx in response.result {
+        if tx.events.iter().any(|event| match event.kind {
+            TxEventKind::Open | TxEventKind::Bid | TxEventKind::Register |
+            TxEventKind::Transfer | TxEventKind::Send | TxEventKind::Renew | TxEventKind::Buy
+            => true,
+            _ => false,
+        }) {
+            main_txs.push(tx);
+        } else { secondary_txs.push(tx); }
+    }
+
+    for tx in main_txs {
+        print_tx_response(network, tx);
+    }
+
+    for tx in secondary_txs {
+        print_tx_response(network, tx);
+    }
+}
+
+pub fn print_error_rpc_response(code: i32, message: String, format: Format) {
+    match format {
+        Format::Text => {
+            println!("⚠️ {}", message);
+        }
+        Format::Json => {
+            let error = FormatRpcError {
+                code,
+                message: message.to_string(),
+            };
+            println!("{}", serde_json::to_string_pretty(&error).unwrap());
+        }
+    }
+}
+
+fn print_tx_response(network: Network, response: TxResponse) {
+    match response.error {
+        None => {
+            println!("{} Transaction {}","✓".color(Color::Green), response.txid);
+        }
+        Some(errors) => {
+            println!("⚠️ Transaction failed to broadcast");
+            for (key, value) in errors.iter() {
+                println!("{}: {}", key, value);
+            }
+
+            println!("\nAttempted actions:")
+        }
+    }
+
+    for event in response.events {
+        println!(" - {} {}", capitalize(event.kind.to_string()), event.space.unwrap_or("".to_string()));
+
+        match event.kind {
+            TxEventKind::Open => {
+                let open_details: OpenEventDetails = serde_json::from_value(
+                    event.details.expect("details"))
+                    .expect("deserialize open event");
+
+                println!("   Initial bid: {}", open_details.initial_bid.to_sat());
+            }
+            TxEventKind::Bid => {
+                let bid_details: BidEventDetails = serde_json::from_value(
+                    event.details.expect("details"))
+                    .expect("deserialize bid event");
+                println!("   New bid: {} (previous {})",
+                         bid_details.current_bid.to_sat(),
+                         bid_details.previous_bid.to_sat()
+                );
+            }
+            TxEventKind::Send => {
+                let send_details: SendEventDetails = serde_json::from_value(
+                    event.details.expect("details"))
+                    .expect("deserialize send event");
+
+                let addr = Address::from_script(send_details.recipient_script_pubkey.as_script(), network)
+                    .expect("valid address");
+
+                println!("   Amount: {}", send_details.amount.to_sat());
+                println!("   Recipient: {}", addr);
+            }
+            TxEventKind::Transfer => {
+                let transfer_details: TransferEventDetails = serde_json::from_value(
+                    event.details.expect("details"))
+                    .expect("deserialize transfer event");
+
+                let addr = SpaceAddress(
+                    Address::from_script(transfer_details.script_pubkey.as_script(), network)
+                        .expect("valid address")
+                );
+                println!("   Recipient: {}", addr);
+            }
+            TxEventKind::Bidout => {
+                let bidout: BidoutEventDetails = serde_json::from_value(
+                    event.details.expect("details"))
+                    .expect("deserialize bidout event");
+                println!("   Count: {}", bidout.count);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn capitalize(mut s: String) -> String {
+    if let Some(first) = s.get_mut(0..1) {
+        first.make_ascii_uppercase();
+    }
+    s
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -14,6 +14,7 @@ pub mod source;
 pub mod store;
 pub mod sync;
 pub mod wallets;
+pub mod format;
 
 fn std_wait<F>(mut predicate: F, wait: Duration)
 where

--- a/node/src/sync.rs
+++ b/node/src/sync.rs
@@ -171,7 +171,8 @@ impl Spaced {
                                 return Err(e);
                             }
                             warn!("Restore: {} - retrying in 1s", e);
-                            std_wait(|| shutdown_signal.try_recv().is_ok(), Duration::from_secs(1));
+                            let mut wait_recv = shutdown.subscribe();
+                            std_wait(|| wait_recv.try_recv().is_ok(), Duration::from_secs(1));
                         }
                         // Even if we couldn't restore just attempt to re-sync
                         let new_tip = self.chain.state.tip.read().expect("read").clone();
@@ -179,7 +180,8 @@ impl Spaced {
                     }
                     BlockEvent::Error(e) => {
                         warn!("Fetcher: {} - retrying in 1s", e);
-                        std_wait(|| shutdown_signal.try_recv().is_ok(), Duration::from_secs(1));
+                        let mut wait_recv = shutdown.subscribe();
+                        std_wait(|| wait_recv.try_recv().is_ok(), Duration::from_secs(1));
                         // Even if we couldn't restore just attempt to re-sync
                         let new_tip = self.chain.state.tip.read().expect("read").clone();
                         fetcher.restart(new_tip, &receiver);

--- a/node/src/wallets.rs
+++ b/node/src/wallets.rs
@@ -182,7 +182,7 @@ impl RpcWallet {
         let (_, fullspaceout) = SpacesWallet::verify_listing::<Sha256>(state, &listing)?;
 
         let space = fullspaceout.spaceout.space.as_ref().expect("space").name.to_string();
-        let foreign_input = fullspaceout.outpoint();
+        let previous_spaceout = fullspaceout.outpoint();
         let tx = wallet.buy::<Sha256>(state, &listing, fee_rate)?;
 
         if !skip_tx_check {
@@ -197,7 +197,7 @@ impl RpcWallet {
         let tx_record = TxRecord::new_with_events(tx, vec![TxEvent {
             kind: TxEventKind::Buy,
             space: Some(space),
-            foreign_input: Some(foreign_input),
+            previous_spaceout: Some(previous_spaceout),
             details: None,
         }]);
 
@@ -599,7 +599,7 @@ impl RpcWallet {
                     continue;
                 }
 
-                if event.foreign_input.is_some_and(|input| input == space.outpoint()) {
+                if event.previous_spaceout.is_some_and(|input| input == space.outpoint()) {
                     continue;
                 }
                 res.outbid.push(space);

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -551,7 +551,7 @@ impl SpacesWallet {
                 txid,
                 event.kind,
                 event.space,
-                event.foreign_input,
+                event.previous_spaceout,
                 event.details,
             ).context("could not insert tx event into wallet db")?;
         }


### PR DESCRIPTION
This PR:

1. simplifies the verbose JSON output for space-cli by introducing a new output format that's text based with nice ASCII tables for various things like `listspaces` and `listtransactions`. 

The raw JSON output can be accessed by specifying `--output-format JSON`.


2. Renames the `foreign_input` column to a more readable name `previous_spaceout`

3. Fixes #66 