### PR TITLE
getblockmeta: allow request by height

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -44,7 +44,7 @@ pub struct BlockMeta {
     pub tx_meta: Vec<TxEntry>,
 }
 
-#[derive(Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct TxEntry {
     #[serde(flatten)]
     pub changeset: TxChangeSet,
@@ -52,7 +52,7 @@ pub struct TxEntry {
     pub tx: Option<TxData>,
 }
 
-#[derive(Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct TxData {
     pub position: u32,
     pub raw: Bytes,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -38,7 +38,7 @@ pub struct Client {
 
 /// A block structure containing validated transaction metadata
 /// relevant to the Spaces protocol
-#[derive(Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct BlockMeta {
     pub height: u32,
     pub tx_meta: Vec<TxEntry>,

--- a/protocol/src/validate.rs
+++ b/protocol/src/validate.rs
@@ -17,7 +17,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct Validator {}
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 /// A `TxChangeSet` captures all resulting state changes.


### PR DESCRIPTION
One can use

```bash
curl -X POST http://127.0.0.1:7224 -H "Content-Type: application/json" -d '{
    "jsonrpc":"2.0",
    "method":"getblockmeta",
    "params":["00000000003a037a98a512ca38147af1d3a21d858596d24f83d65fbf2f6d5131"],
    "id":1
}'
```

or

```bash
curl -X POST http://127.0.0.1:7224 -H "Content-Type: application/json" -d '{
    "jsonrpc":"2.0",
    "method":"getblockmeta",
    "params":[55879],
    "id":1
}'
```

Both calls will return the same result

```json
{
  "jsonrpc": "2.0",
  "result": {
    "hash": "00000000003a037a98a512ca38147af1d3a21d858596d24f83d65fbf2f6d5131",
    "height": 55879,
    "tx_meta": [
      {
        "txid": "394ebef5203c4306c3f7a6d1a5c2058bac130deb24c1d7725094b31d1ff54ea4",
        "spends": [
          {
            "n": 0
          }
        ],
        "creates": [
          {
            "n": 0,
            "value": 662,
            "script_pubkey": "512065a7b5051fe33239e6ddb0d69e809a74d1702fde541bdf3431c6994b72317f33"
          }
        ],
        "updates": []
      },
      {
        "txid": "f811529d79c9fc808c240a1b5087ba19610c4177a01ffa8047c3cc143cf3eb1a",
        "spends": [
          {
            "n": 0
          },
          {
            "n": 1
          },
          {
            "n": 2
          },
          {
            "n": 3
          }
        ],
        "creates": [
          {
            "n": 1,
            "name": "@bitcoin",
            "covenant": {
              "type": "transfer",
              "expire_height": 108439,
              "data": "68656c6c6f20776f726c64"
            },
            "value": 666,
            "script_pubkey": "5120611454515f9fe8c656f80c51de229dc5d9cba9a05d00486b43a1e9033ef6393b"
          }
        ],
        "updates": []
      }
    ]
  },
  "id": 1
}
```