### PR TITLE
returned back grep for shell detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ add_to_path() {
   local reload_needed=false
 
   # Detect shell configuration file based on $SHELL environment variable
-  if [[ "$SHELL" == */zsh ]]; then
+  if echo "$SHELL" | grep -q "zsh"; then
     shell_rc="$HOME/.zshrc"
     shell_type="zsh"
   else


### PR DESCRIPTION
Returning grep for shell detection:

In the current version `if [[ "$SHELL" == */zsh ]]; then` produces an error when using it via curl like this:

`curl --proto '=https' --tlsv1.2 -sSf https://install.spacesprotocol.org/ | sh`,

as double bracket matching [[...]] is actually not part of POSIX so `sh` cannot really use it, while it can use `grep` which is POSIX and should be in all shells.
