### PR TITLE
Refactor sync checks

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -14,7 +14,7 @@ use spaces_protocol::{
     validate::{TxChangeSet, UpdateKind, Validator},
     Bytes, Covenant, FullSpaceOut, RevokeReason, SpaceOut,
 };
-use spaces_wallet::bitcoin::Transaction;
+use spaces_wallet::bitcoin::{Network, Transaction};
 
 use crate::{
     source::BitcoinRpcError,
@@ -27,7 +27,7 @@ pub trait BlockSource {
     fn get_median_time(&self) -> Result<u64, BitcoinRpcError>;
     fn in_mempool(&self, txid: &Txid, height: u32) -> Result<bool, BitcoinRpcError>;
     fn get_block_count(&self) -> Result<u64, BitcoinRpcError>;
-    fn get_best_chain(&self) -> Result<ChainAnchor, BitcoinRpcError>;
+    fn get_best_chain(&self, tip: Option<u32>, expected_chain: Network) -> Result<Option<ChainAnchor>, BitcoinRpcError>;
 }
 
 #[derive(Debug, Clone)]

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -79,6 +79,9 @@ pub struct Args {
     /// Skip maintaining historical root anchors
     #[arg(long, env = "SPACED_SKIP_ANCHORS", default_value = "false")]
     skip_anchors: bool,
+    /// The specified Bitcoin RPC is a light client
+    #[arg(long, env = "SPACED_BITCOIN_RPC_LIGHT", default_value = "false")]
+    bitcoin_rpc_light: bool,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum, Serialize, Deserialize)]
@@ -164,6 +167,7 @@ impl Args {
         let rpc = BitcoinRpc::new(
             &args.bitcoin_rpc_url.expect("bitcoin rpc url"),
             bitcoin_rpc_auth,
+            !args.bitcoin_rpc_light
         );
 
         let genesis = Spaced::genesis(&rpc, args.chain).await?;

--- a/client/src/format.rs
+++ b/client/src/format.rs
@@ -152,9 +152,10 @@ pub fn print_list_unspent(utxos: Vec<WalletOutput>, format: Format) {
 pub fn print_server_info(info: ServerInfo, format: Format) {
     match format {
         Format::Text => {
-            println!("CHAIN: {}", info.network);
-            println!("  Height {}", info.tip.height);
-            println!("  Hash {}", info.tip.hash);
+            println!("Network: {}", info.network);
+            println!("Height {}", info.tip.height);
+            println!("Hash {}", info.tip.hash);
+            println!("Progress {:.2}%", info.progress * 100.0);
         }
         Format::Json => {
             println!("{}", serde_json::to_string_pretty(&info).unwrap());

--- a/client/src/format.rs
+++ b/client/src/format.rs
@@ -152,7 +152,7 @@ pub fn print_list_unspent(utxos: Vec<WalletOutput>, format: Format) {
 pub fn print_server_info(info: ServerInfo, format: Format) {
     match format {
         Format::Text => {
-            println!("CHAIN: {}", info.chain);
+            println!("CHAIN: {}", info.network);
             println!("  Height {}", info.tip.height);
             println!("  Hash {}", info.tip.hash);
         }

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -1591,7 +1591,7 @@ async fn get_server_info(client: &reqwest::Client, rpc: &BitcoinRpc, tip: ChainA
             blocks: info.blocks,
             headers: info.headers,
         },
-        progress: if info.headers >= tip.height {
+        progress: if info.headers != 0 && info.headers >= tip.height {
             tip.height as f32 / info.headers as f32
         } else {
             0.0

--- a/client/src/sync.rs
+++ b/client/src/sync.rs
@@ -189,7 +189,11 @@ impl Spaced {
             start_block.hash, start_block.height
         );
 
-        let (fetcher, receiver) = BlockFetcher::new(source.clone(), self.num_workers);
+        let (fetcher, receiver) = BlockFetcher::new(
+            self.network.fallback_network(),
+            source.clone(),
+            self.num_workers,
+        );
         fetcher.start(start_block);
 
         let mut shutdown_signal = shutdown.subscribe();

--- a/client/src/wallets.rs
+++ b/client/src/wallets.rs
@@ -363,9 +363,9 @@ impl RpcWallet {
                     .get_best_chain(Some(wallet_info.tip), wallet.config.network);
                 if let Ok(Some(best_chain)) = best_chain {
                     wallet_info.progress = if best_chain.height >= wallet_info.tip {
-                        Some(wallet_info.tip as f32 / best_chain.height as f32)
+                        wallet_info.tip as f32 / best_chain.height as f32
                     } else {
-                        None
+                        0.0
                     }
                 }
 

--- a/client/tests/fetcher_tests.rs
+++ b/client/tests/fetcher_tests.rs
@@ -8,6 +8,7 @@ use spaces_client::source::{
     BitcoinBlockSource, BitcoinRpc, BitcoinRpcAuth, BlockEvent, BlockFetcher,
 };
 use spaces_protocol::{bitcoin::BlockHash, constants::ChainAnchor};
+use spaces_protocol::bitcoin::Network;
 use spaces_testutil::TestRig;
 
 async fn setup(blocks: u64) -> Result<(TestRig, u64, BlockHash)> {
@@ -27,8 +28,9 @@ fn test_block_fetching_from_bitcoin_rpc() -> Result<()> {
     let fetcher_rpc = BitcoinBlockSource::new(BitcoinRpc::new(
         &rig.bitcoind.rpc_url(),
         BitcoinRpcAuth::UserPass("user".to_string(), "password".to_string()),
+        true
     ));
-    let (fetcher, receiver) = BlockFetcher::new(fetcher_rpc.clone(), 8);
+    let (fetcher, receiver) = BlockFetcher::new(Network::Regtest, fetcher_rpc.clone(), 8);
     fetcher.start(ChainAnchor { hash, height: 0 });
 
     let timeout = Duration::from_secs(5);

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -104,6 +104,7 @@ pub struct WalletInfo {
     pub start_block: u32,
     pub tip: u32,
     pub descriptors: Vec<DescriptorInfo>,
+    pub progress: Option<f32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -589,6 +590,7 @@ impl SpacesWallet {
             start_block: self.config.start_block,
             tip: self.internal.local_chain().tip().height(),
             descriptors,
+            progress: None,
         }
     }
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -104,7 +104,7 @@ pub struct WalletInfo {
     pub start_block: u32,
     pub tip: u32,
     pub descriptors: Vec<DescriptorInfo>,
-    pub progress: Option<f32>,
+    pub progress: f32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -590,7 +590,7 @@ impl SpacesWallet {
             start_block: self.config.start_block,
             tip: self.internal.local_chain().tip().height(),
             descriptors,
-            progress: None,
+            progress: 0.0,
         }
     }
 


### PR DESCRIPTION
This PR introduces a few improvements to sync checks.

1. If spaces tip > the rpc endpoint's tip, it waits for the node to sync. This can happen if a user starts spaces but the Bitcoin node is still syncing.
2. Add `progress` to getserverinfo and getwalletinfo.
3. Add `--bitcoin-rpc-light` option to indicate that we're connecting a light-ish style node. 
4. A few other clean ups