### PR TITLE
exportspacensec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .zone
 
 NOTES.md
+temp/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target
 .idea
 .DS_store
 .zone
+
+NOTES.md

--- a/client/src/bin/space-cli.rs
+++ b/client/src/bin/space-cli.rs
@@ -299,11 +299,8 @@ enum Commands {
     ExportSpaceNsec {
         /// The space to use for exporting the Nostr nsec key
         space: String,
-        /// The DNS zone file path (omit for stdin)
-        input: Option<PathBuf>,
-        /// Skip including bundled Merkle proof in the event.
-        #[arg(long)]
-        skip_anchor: bool,
+        /// Destination path to export nsec key file
+        path: PathBuf,
     },
     /// Updates the Merkle trust path for space-anchored Nostr events
     #[command(name = "refreshanchor")]
@@ -481,6 +478,15 @@ impl SpaceCli {
             result = self.add_anchor(result, most_recent).await?
         }
 
+        Ok(result)
+    }
+
+    async fn get_space_nsec_keys(&self, space: String) -> Result<(String, String), ClientError> {
+        let result = self
+            .client
+            .wallet_get_space_nsec_keys(&self.wallet, &space)
+            .await?;
+        
         Ok(result)
     }
 
@@ -964,14 +970,14 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
         }
         Commands::ExportSpaceNsec {
             space,
-            input,
-            skip_anchor,
+            path,
         } => {
-            let update = encode_dns_update(&space, input)
-                .map_err(|e| ClientError::Custom(format!("Parse error: {}", e)))?;
-            let result = cli.sign_event(space, update, !skip_anchor, false).await?;
-
-            println!("{}", serde_json::to_string(&result).expect("result"));
+            let (secret_hex, nsec) = cli.get_space_nsec_keys(space).await?;
+            
+            let content = format!("secret_hex: {}\nnsec: {}", secret_hex, nsec);
+            fs::write(path, content).map_err(|e| {
+                ClientError::Custom(format!("Could not save to path: {}", e.to_string()))
+            })?;
         }
         Commands::RefreshAnchor {
             input,

--- a/client/src/bin/space-cli.rs
+++ b/client/src/bin/space-cli.rs
@@ -294,6 +294,17 @@ enum Commands {
         #[arg(long)]
         skip_anchor: bool,
     },
+    /// Export a space's Nostr nsec key
+    #[command(name = "exportspacensec")]
+    ExportSpaceNsec {
+        /// The space to use for exporting the Nostr nsec key
+        space: String,
+        /// The DNS zone file path (omit for stdin)
+        input: Option<PathBuf>,
+        /// Skip including bundled Merkle proof in the event.
+        #[arg(long)]
+        skip_anchor: bool,
+    },
     /// Updates the Merkle trust path for space-anchored Nostr events
     #[command(name = "refreshanchor")]
     RefreshAnchor {
@@ -453,6 +464,26 @@ impl SpaceCli {
 
         Ok(result)
     }
+
+    async fn export_space_nsec(
+        &self,
+        space: String,
+        event: NostrEvent,
+        anchor: bool,
+        most_recent: bool,
+    ) -> Result<NostrEvent, ClientError> {
+        let mut result = self
+            .client
+            .wallet_sign_event(&self.wallet, &space, event)
+            .await?;
+
+        if anchor {
+            result = self.add_anchor(result, most_recent).await?
+        }
+
+        Ok(result)
+    }
+
     async fn add_anchor(
         &self,
         mut event: NostrEvent,
@@ -921,6 +952,17 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
             println!("{}", serde_json::to_string(&result).expect("result"));
         }
         Commands::SignZone {
+            space,
+            input,
+            skip_anchor,
+        } => {
+            let update = encode_dns_update(&space, input)
+                .map_err(|e| ClientError::Custom(format!("Parse error: {}", e)))?;
+            let result = cli.export_space_nsec(space, update, !skip_anchor, false).await?;
+
+            println!("{}", serde_json::to_string(&result).expect("result"));
+        }
+        Commands::ExportSpaceNsec {
             space,
             input,
             skip_anchor,

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -235,6 +235,14 @@ pub trait Rpc {
         event: NostrEvent,
     ) -> Result<NostrEvent, ErrorObjectOwned>;
 
+    #[method(name = "walletexportnsec")]
+    async fn wallet_export_nsec(
+        &self,
+        wallet: &str,
+        space: &str,
+        event: NostrEvent,
+    ) -> Result<NostrEvent, ErrorObjectOwned>;
+
     #[method(name = "walletgetinfo")]
     async fn wallet_get_info(&self, name: &str)
         -> Result<WalletInfoWithProgress, ErrorObjectOwned>;
@@ -904,6 +912,19 @@ impl RpcServer for RpcServerImpl {
     }
 
     async fn wallet_sign_event(
+        &self,
+        wallet: &str,
+        space: &str,
+        event: NostrEvent,
+    ) -> Result<NostrEvent, ErrorObjectOwned> {
+        self.wallet(&wallet)
+            .await?
+            .send_sign_event(space, event)
+            .await
+            .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
+    }
+
+    async fn wallet_export_nsec(
         &self,
         wallet: &str,
         space: &str,

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -243,6 +243,13 @@ pub trait Rpc {
         event: NostrEvent,
     ) -> Result<NostrEvent, ErrorObjectOwned>;
 
+    #[method(name = "walletgetspacenseckeys")]
+    async fn wallet_get_space_nsec_keys(
+        &self,
+        wallet: &str,
+        space: &str,
+    ) -> Result<(String, String), ErrorObjectOwned>;
+
     #[method(name = "walletgetinfo")]
     async fn wallet_get_info(&self, name: &str)
         -> Result<WalletInfoWithProgress, ErrorObjectOwned>;
@@ -933,6 +940,18 @@ impl RpcServer for RpcServerImpl {
         self.wallet(&wallet)
             .await?
             .send_sign_event(space, event)
+            .await
+            .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
+    }
+
+    async fn wallet_get_space_nsec_keys(
+        &self,
+        wallet: &str,
+        space: &str,
+    ) -> Result<(String, String), ErrorObjectOwned> {
+        self.wallet(&wallet)
+            .await?
+            .send_get_space_nsec_keys(space)
             .await
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
     }

--- a/client/src/wallets.rs
+++ b/client/src/wallets.rs
@@ -214,6 +214,11 @@ pub enum WalletCommand {
         event: NostrEvent,
         resp: crate::rpc::Responder<anyhow::Result<NostrEvent>>,
     },
+    ExportSpaceNsec {
+        space: String,
+        event: NostrEvent,
+        resp: crate::rpc::Responder<anyhow::Result<NostrEvent>>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, ValueEnum)]
@@ -516,6 +521,9 @@ impl RpcWallet {
             }
             WalletCommand::SignEvent { space, event, resp } => {
                 _ = resp.send(wallet.sign_event::<Sha256>(state, &space, event));
+            }
+            WalletCommand::ExportSpaceNsec { space, event, resp } => {
+                _ = resp.send(wallet.export_space_nsec::<Sha256>(state, &space, event));
             }
         }
         Ok(())

--- a/client/src/wallets.rs
+++ b/client/src/wallets.rs
@@ -219,6 +219,10 @@ pub enum WalletCommand {
         event: NostrEvent,
         resp: crate::rpc::Responder<anyhow::Result<NostrEvent>>,
     },
+    GetSpaceNsecKeys {
+        space: String,
+        resp: crate::rpc::Responder<anyhow::Result<(String, String)>>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, ValueEnum)]
@@ -524,6 +528,9 @@ impl RpcWallet {
             }
             WalletCommand::ExportSpaceNsec { space, event, resp } => {
                 _ = resp.send(wallet.export_space_nsec::<Sha256>(state, &space, event));
+            }
+            WalletCommand::GetSpaceNsecKeys { space, resp } => {
+                _ = resp.send(wallet.get_space_nsec_keys::<Sha256>(state, &space));
             }
         }
         Ok(())
@@ -1476,6 +1483,20 @@ impl RpcWallet {
             .send(WalletCommand::SignEvent {
                 space: space.to_string(),
                 event,
+                resp,
+            })
+            .await?;
+        resp_rx.await?
+    }
+
+    pub async fn send_get_space_nsec_keys(
+        &self,
+        space: &str,
+    ) -> anyhow::Result<(String, String)> {
+        let (resp, resp_rx) = oneshot::channel();
+        self.sender
+            .send(WalletCommand::GetSpaceNsecKeys {
+                space: space.to_string(),
                 resp,
             })
             .await?;

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, fmt::Debug, fs, ops::Mul, path::PathBuf, str::FromStr};
 use anyhow::{anyhow, Context};
+use bech32::{Bech32, Hrp, encode};
 use bdk_wallet::{
     chain,
     chain::{
@@ -419,6 +420,50 @@ impl SpacesWallet {
 
         event.sign(secp256k1::Secp256k1::new(), &keypair.to_inner())?;
         Ok(event)
+    }
+
+    pub fn export_space_nsec<H: KeyHasher>(
+        &mut self,
+        src: &mut impl DataSource,
+        space: &str,
+        mut event: NostrEvent,
+    ) -> anyhow::Result<NostrEvent> {
+        if event.space().is_some_and(|s| s != space) {
+            return Err(anyhow::anyhow!("Space tag does not match specified space"));
+        }
+
+        let label = SLabel::from_str(space)?;
+        let space_key = SpaceKey::from(H::hash(label.as_ref()));
+        let outpoint = match src.get_space_outpoint(&space_key)? {
+            None => return Err(anyhow::anyhow!("Space not found")),
+            Some(outpoint) => outpoint,
+        };
+        let utxo = match self.get_utxo(outpoint) {
+            None => return Err(anyhow::anyhow!("Space not owned by wallet")),
+            Some(utxo) => utxo,
+        };
+
+        // derive taproot keypair for space XXX
+        let keypair = self
+            .get_taproot_keypair(utxo.keychain, utxo.derivation_index) // derive taproot keypair for space
+            .context("Could not derive taproot keypair to sign message")?; // propagate derivation errors
+
+        // WARNING: printing private keys is insecure; do this only for debugging
+        let inner = keypair.to_inner();
+        let secret = inner.secret_key();
+        let secret_bytes = secret.secret_bytes();
+        let secret_hex = hex::encode(secret_bytes);
+        
+        // Convert to nsec format (nostr bech32 encoding)
+        let hrp = Hrp::parse("nsec").unwrap_or_else(|_| Hrp::parse("nsec").unwrap());
+        let nsec = encode::<Bech32>(hrp, &secret_bytes)
+            .unwrap_or_else(|_| "encoding_failed".to_string());
+        
+        println!("Signing with private key (hex): {}", secret_hex);
+        println!("Signing with private key (nsec): {}", nsec);
+
+        event.sign(secp256k1::Secp256k1::new(), &inner)?; // perform Schnorr signature with taproot key
+        Ok(event) // return the now-signed event
     }
 
     pub fn verify_event<H: KeyHasher>(

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -466,6 +466,40 @@ impl SpacesWallet {
         Ok(event) // return the now-signed event
     }
 
+    pub fn get_space_nsec_keys<H: KeyHasher>(
+        &mut self,
+        src: &mut impl DataSource,
+        space: &str,
+    ) -> anyhow::Result<(String, String)> {
+        let label = SLabel::from_str(space)?;
+        let space_key = SpaceKey::from(H::hash(label.as_ref()));
+        let outpoint = match src.get_space_outpoint(&space_key)? {
+            None => return Err(anyhow::anyhow!("Space not found")),
+            Some(outpoint) => outpoint,
+        };
+        let utxo = match self.get_utxo(outpoint) {
+            None => return Err(anyhow::anyhow!("Space not owned by wallet")),
+            Some(utxo) => utxo,
+        };
+
+        // derive taproot keypair for space
+        let keypair = self
+            .get_taproot_keypair(utxo.keychain, utxo.derivation_index)
+            .context("Could not derive taproot keypair")?;
+
+        let inner = keypair.to_inner();
+        let secret = inner.secret_key();
+        let secret_bytes = secret.secret_bytes();
+        let secret_hex = hex::encode(secret_bytes);
+        
+        // Convert to nsec format (nostr bech32 encoding)
+        let hrp = Hrp::parse("nsec").unwrap_or_else(|_| Hrp::parse("nsec").unwrap());
+        let nsec = encode::<Bech32>(hrp, &secret_bytes)
+            .unwrap_or_else(|_| "encoding_failed".to_string());
+        
+        Ok((secret_hex, nsec))
+    }
+
     pub fn verify_event<H: KeyHasher>(
         src: &mut impl DataSource,
         space: &str,


### PR DESCRIPTION
Thinking about the broader spaces protocol operator ecosystem, a future entity that wants to provide a platform to service space owners would want the ability to require that a top-level space it indeed owned by the person claiming to own it.

This can be easily accomplished by providing a simple nostr event and asking the owner to sign it with their key.

space-cli signevent

The signed event could then be returned to the platform operator and verified with.

space-cli verifyevent

While this works in a rudimentary way, if the platform operator and/or the space owner wants to keep the line of communication open for future announcements and/or questions and/or billing/payment issues without actually knowing who each other are, it is cumbersome to continue using the space-cli subcommands.

This new subcommand exportspacensec behaves similar to exportwallet in that it creates a file with the exported content.  In this case it is the nostr nsec and hex encoded format of the private key for that derivative path of that space.

This allows for easy Nostr client account setup and allows for monitoring of messages and using direct messages between the space owner and the platform operator.