### PR TITLE
Introduce commitment finality and different PTR transfer mechanisms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,6 +2419,7 @@ dependencies = [
  "ring",
  "spacedb",
  "spaces_protocol",
+ "spaces_ptr",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,6 +2384,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitcoin",
+ "hex",
  "log",
  "rand",
  "serde",

--- a/SUBSPACES.md
+++ b/SUBSPACES.md
@@ -4,10 +4,10 @@
 
 ### 1. Initialize the Space
 
-Initialize your space for operation:
+Delegate your space to a UTXO that can be used to submit commitments:
 
 ```bash
-$ space-cli operate @bitcoin
+$ space-cli delegate @bitcoin
 ```
 
 ### 2. Issue Subspaces
@@ -57,12 +57,12 @@ $ space-cli getcommitment @bitcoin
 ```
 
 
-### Delegating Operational Control
+### Authorizing Operational Control
 
-You can authorize another party to make commitments on your behalf:
+You can authorize another party to make commitments on your behalf by transferring the space pointer:
 
 ```bash
-$ space-cli delegate @bitcoin --to <operator-address>
+$ space-cli authorize @bitcoin --to <operator-address>
 ```
 
 ## Binding Handles On-Chain

--- a/client/src/bin/space-cli.rs
+++ b/client/src/bin/space-cli.rs
@@ -157,6 +157,8 @@ enum Commands {
     CreatePtr {
         /// The script public key as hex string
         spk: String,
+
+        #[arg(long, short)]
         fee_rate: Option<u64>,
     },
     /// Get ptr info
@@ -211,7 +213,6 @@ enum Commands {
     #[command(name = "operate")]
     Operate {
         /// The space to apply new root
-        #[arg(display_order = 0)]
         space: String,
         /// Fee rate to use in sat/vB
         #[arg(long, short)]
@@ -221,10 +222,8 @@ enum Commands {
     #[command(name = "commit")]
     Commit {
         /// The space to apply new root
-        #[arg(display_order = 0)]
         space: String,
         /// The new state root
-        #[arg(long, display_order = 1)]
         root: sha256::Hash,
         /// Fee rate to use in sat/vB
         #[arg(long, short)]
@@ -1167,7 +1166,7 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
             cli.send_request(
                 Some(RpcWalletRequest::Commit(CommitParams {
                     space: label.clone(),
-                    root,
+                    root: Some(root),
                 })),
                 None,
                 fee_rate,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -15,7 +15,7 @@ use spaces_protocol::{
     validate::{TxChangeSet, UpdateKind, Validator},
     Bytes, Covenant, FullSpaceOut, RevokeReason, SpaceOut,
 };
-use spaces_ptr::{CommitmentKey, RegistryKey, RegistrySptrKey};
+use spaces_ptr::{CommitmentKey, RegistryKey, RegistrySptrKey, PtrOutpointKey};
 use spaces_wallet::bitcoin::{Network, Transaction};
 
 use crate::{
@@ -348,7 +348,7 @@ impl Client {
             }
 
             // Outpoint => PtrOut
-            let outpoint_key = OutpointKey::from_outpoint::<Sha256>(outpoint);
+            let outpoint_key = PtrOutpointKey::from_outpoint::<Sha256>(outpoint);
             state.insert_ptrout(outpoint_key, create);
         }
     }

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -489,6 +489,8 @@ pub enum RpcWalletRequest {
     Delegate(DelegateParams),
     #[serde(rename = "commit")]
     Commit(CommitParams),
+    #[serde(rename = "setptrdata")]
+    SetPtrData(SetPtrDataParams),
     #[serde(rename = "send")]
     SendCoins(SendCoinsParams),
 }
@@ -523,6 +525,11 @@ pub struct CommitParams {
     pub root: Option<sha256::Hash>,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SetPtrDataParams {
+    pub sptr: Sptr,
+    pub data: Vec<u8>,
+}
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SendCoinsParams {

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -48,7 +48,7 @@ use tokio::{
     task::JoinSet,
 };
 use spaces_protocol::hasher::Hash;
-use spaces_ptr::{PtrSource, FullPtrOut, PtrOut, Commitment, RegistryKey, CommitmentKey, RegistrySptrKey};
+use spaces_ptr::{PtrSource, FullPtrOut, PtrOut, Commitment, RegistryKey, CommitmentKey, RegistrySptrKey, PtrOutpointKey};
 use spaces_ptr::sptr::Sptr;
 use spaces_wallet::bitcoin::hashes::sha256;
 use crate::auth::BasicAuthLayer;
@@ -1853,7 +1853,7 @@ impl AsyncChainState {
         outpoint: OutPoint,
         prefer_recent: bool,
     ) -> anyhow::Result<ProofResult> {
-        let key = OutpointKey::from_outpoint::<Sha256>(outpoint);
+        let key = PtrOutpointKey::from_outpoint::<Sha256>(outpoint);
 
         let proof = if !prefer_recent {
             let ptrout = match state.get_ptrout(&outpoint)? {

--- a/client/src/store/chain.rs
+++ b/client/src/store/chain.rs
@@ -336,6 +336,14 @@ impl Chain {
         self.db.sp.state.prove_with_snapshot(keys, snapshot_block_height)
     }
 
+    pub fn prove_ptrs_with_snapshot(
+        &self,
+        keys: &[Hash],
+        snapshot_block_height: u32,
+    ) -> anyhow::Result<SubTree<Sha256Hasher>> {
+        self.db.pt.state.prove_with_snapshot(keys, snapshot_block_height)
+    }
+
     pub fn get_spaces_block(&mut self, hash: BlockHash) -> anyhow::Result<Option<BlockMetaWithHash>> {
         let idx = match &mut self.idx.sp  {
             None => return Err(anyhow!("spaces index must be enabled")),

--- a/client/src/store/chain.rs
+++ b/client/src/store/chain.rs
@@ -10,7 +10,7 @@ use spaces_protocol::hasher::{BaseHash, BidKey, OutpointKey, SpaceKey};
 use spaces_protocol::prepare::SpacesSource;
 use spaces_protocol::{FullSpaceOut, SpaceOut};
 use spaces_protocol::slabel::SLabel;
-use spaces_ptr::{Commitment, CommitmentKey, FullPtrOut, PtrOut, PtrSource, RegistryKey, RegistrySptrKey};
+use spaces_ptr::{Commitment, CommitmentKey, FullPtrOut, PtrOut, PtrSource, RegistryKey, RegistrySptrKey, PtrOutpointKey};
 use spaces_ptr::sptr::Sptr;
 use spaces_wallet::bitcoin::Network;
 use crate::client::{BlockMeta, PtrBlockMeta};
@@ -276,7 +276,7 @@ impl Chain {
         tip.hash = block_hash;
     }
 
-    pub(crate) fn insert_ptrout(&self, key: OutpointKey, ptrout: PtrOut) {
+    pub(crate) fn insert_ptrout(&self, key: PtrOutpointKey, ptrout: PtrOut) {
         self.db.pt.state.insert(key, ptrout)
     }
 

--- a/client/src/store/chain.rs
+++ b/client/src/store/chain.rs
@@ -14,7 +14,7 @@ use spaces_ptr::{Commitment, CommitmentKey, FullPtrOut, PtrOut, PtrSource, Regis
 use spaces_ptr::sptr::Sptr;
 use spaces_wallet::bitcoin::Network;
 use crate::client::{BlockMeta, PtrBlockMeta};
-use crate::rpc::BlockMetaWithHash;
+use crate::rpc::{BlockMetaWithHash, PtrBlockMetaWithHash};
 use crate::store::{EncodableOutpoint, ReadTx, Sha256};
 use crate::store::ptrs::{PtrChainState, PtrLiveStore, PtrStore};
 use crate::store::spaces::{RolloutEntry, RolloutIterator, SpLiveStore, SpStore, SpStoreUtils, SpacesState};
@@ -288,6 +288,10 @@ impl Chain {
         self.db.pt.state.insert_registry_delegation(key, space)
     }
 
+    pub fn remove_delegation(&mut self, delegation: RegistrySptrKey) {
+        self.db.pt.state.remove(delegation)
+    }
+
     pub(crate) fn insert_commitment(&self, key: CommitmentKey, commitment: Commitment) {
         self.db.pt.state.insert_commitment(key, commitment)
     }
@@ -301,8 +305,10 @@ impl Chain {
         self.db.pt.state.remove(key)
     }
 
-    pub fn remove_delegation(&mut self, delegation: RegistrySptrKey) {
-        self.db.pt.state.remove(delegation)
+
+
+    pub fn remove_commitment(&mut self, commitment: CommitmentKey) {
+        self.db.pt.state.remove(commitment)
     }
 
     pub fn remove_space_utxo(&mut self, outpoint: OutPoint) {
@@ -339,6 +345,21 @@ impl Chain {
         let block = idx.state.get(key).context("could not retrieve block meta")?;
         Ok(block.map(|b| {
            BlockMetaWithHash {
+               hash,
+               block_meta: b,
+           }
+        }))
+    }
+
+    pub fn get_ptrs_block(&mut self, hash: BlockHash) -> anyhow::Result<Option<PtrBlockMetaWithHash>> {
+        let idx = match &mut self.idx.pt  {
+            None => return Err(anyhow!("ptrs index must be enabled")),
+            Some(idx) => idx
+        };
+        let key = BaseHash::from_slice(hash.as_ref());
+        let block = idx.state.get(key).context("could not retrieve ptr block meta")?;
+        Ok(block.map(|b| {
+           PtrBlockMetaWithHash {
                hash,
                block_meta: b,
            }
@@ -467,21 +488,75 @@ impl Chain {
     }
 
     pub fn update_anchors(&self, anchors_path: &Path) -> anyhow::Result<()> {
-        // TODO: merge ptrs anchor
+        use std::collections::HashMap;
+        use std::fs;
+        use std::io;
+        use crate::rpc::RootAnchor;
+
         info!("Updating root anchors ...");
-        let result = self
-            .db
-            .sp
-            .store
-            .update_anchors(anchors_path, ROOT_ANCHORS_COUNT)
-            .or_else(|e| Err(anyhow!("Could not update trust anchors: {}", e)))?;
-        if let Some(result) = result.first() {
-            info!(
-                "Latest root anchor {} (height: {})",
-                hex::encode(result.root),
-                result.block.height
-            )
+
+        // Load previous anchors from file
+        let previous: Vec<RootAnchor> = match fs::read(anchors_path) {
+            Ok(bytes) => serde_json::from_slice(&bytes)?,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Vec::new(),
+            Err(e) => return Err(e.into()),
+        };
+
+        let prev_map: HashMap<(BlockHash, u32), RootAnchor> = previous
+            .into_iter()
+            .map(|anchor| ((anchor.block.hash, anchor.block.height), anchor))
+            .collect();
+
+        let mut anchors = Vec::new();
+        let sp_iter = self.db.sp.store.iter().take(ROOT_ANCHORS_COUNT as _);
+        let mut pt_iter = self.db.pt.store.iter();
+
+        for sp_snap in sp_iter {
+            let mut sp_snap = sp_snap?;
+            let anchor: ChainAnchor = sp_snap.metadata().try_into()?;
+
+            // Check if we can get PTR snapshot at the same height
+            let mut ptrs_root = None;
+            if let Some(pt_snap) = pt_iter.next() {
+                if let Ok(mut pt_snap) = pt_snap {
+                    let pt_anchor: ChainAnchor = pt_snap.metadata().try_into()?;
+                    // Only include PTR root if it matches the same block
+                    if pt_anchor.height == anchor.height && pt_anchor.hash == anchor.hash {
+                        ptrs_root = Some(pt_snap.compute_root()?);
+                    }
+                }
+            }
+
+            if let Some(existing) = prev_map.get(&(anchor.hash, anchor.height)) {
+                // Preserve existing anchor but update ptrs_root if we have a new one
+                let updated_anchor = RootAnchor {
+                    spaces_root: existing.spaces_root,
+                    ptrs_root: ptrs_root.or(existing.ptrs_root),
+                    block: existing.block.clone(),
+                };
+                anchors.push(updated_anchor);
+            } else {
+                let spaces_root = sp_snap.compute_root()?;
+                anchors.push(RootAnchor {
+                    spaces_root,
+                    ptrs_root,
+                    block: anchor,
+                });
+            }
         }
+
+        let updated = serde_json::to_vec_pretty(&anchors)?;
+        fs::write(anchors_path, updated)?;
+
+        if let Some(result) = anchors.first() {
+            info!(
+                "Latest root anchor spaces={} ptrs={} (height: {})",
+                hex::encode(result.spaces_root),
+                result.ptrs_root.as_ref().map(hex::encode).unwrap_or_else(|| "none".to_string()),
+                result.block.height
+            );
+        }
+
         Ok(())
     }
 }

--- a/client/src/store/ptrs.rs
+++ b/client/src/store/ptrs.rs
@@ -20,10 +20,10 @@ use spacedb::{
 use spaces_protocol::{
     bitcoin::{BlockHash, OutPoint},
     constants::{ChainAnchor},
-    hasher::{KeyHash, OutpointKey},
+    hasher::{KeyHash},
 };
 use spaces_protocol::slabel::SLabel;
-use spaces_ptr::{Commitment, CommitmentKey, FullPtrOut, PtrOut, PtrSource, RegistryKey, RegistrySptrKey};
+use spaces_ptr::{Commitment, CommitmentKey, FullPtrOut, PtrOut, PtrSource, RegistryKey, RegistrySptrKey, PtrOutpointKey};
 use spaces_ptr::sptr::Sptr;
 use crate::store::{EncodableOutpoint, Sha256};
 
@@ -110,7 +110,7 @@ impl PtrStore {
 }
 
 pub trait PtrChainState {
-    fn insert_ptrout(&self, key: OutpointKey, ptrout: PtrOut);
+    fn insert_ptrout(&self, key: PtrOutpointKey, ptrout: PtrOut);
     fn insert_commitment(&self, key: CommitmentKey, commitment: Commitment);
     fn insert_registry(&self, key: RegistryKey, state_root: Hash);
     fn insert_registry_delegation(&self, key: RegistrySptrKey, space: SLabel);
@@ -124,7 +124,7 @@ pub trait PtrChainState {
 }
 
 impl PtrChainState for PtrLiveSnapshot {
-    fn insert_ptrout(&self, key: OutpointKey, ptrout: PtrOut) {
+    fn insert_ptrout(&self, key: PtrOutpointKey, ptrout: PtrOut) {
         self.insert(key, ptrout)
     }
 
@@ -351,7 +351,7 @@ impl PtrSource for PtrLiveSnapshot {
         &mut self,
         outpoint: &OutPoint,
     ) -> spaces_protocol::errors::Result<Option<PtrOut>> {
-        let h = OutpointKey::from_outpoint::<Sha256>(*outpoint);
+        let h = PtrOutpointKey::from_outpoint::<Sha256>(*outpoint);
         let result = self.get(h).map_err(|err| {
             spaces_protocol::errors::Error::IO(format!("getptrout: {}", err.to_string()))
         })?;

--- a/client/src/store/ptrs.rs
+++ b/client/src/store/ptrs.rs
@@ -124,8 +124,8 @@ pub trait PtrChainState {
 }
 
 impl PtrChainState for PtrLiveSnapshot {
-    fn insert_ptrout(&self, key: OutpointKey, spaceout: PtrOut) {
-        self.insert(key, spaceout)
+    fn insert_ptrout(&self, key: OutpointKey, ptrout: PtrOut) {
+        self.insert(key, ptrout)
     }
 
     fn insert_commitment(&self, key: CommitmentKey, commitment: Commitment) {

--- a/client/src/store/spaces.rs
+++ b/client/src/store/spaces.rs
@@ -110,9 +110,10 @@ impl SpStore {
             if let Some(existing) = prev_map.get(&(anchor.hash, anchor.height)) {
                 anchors.push(existing.clone());
             } else {
-                let root = snap.compute_root()?;
+                let spaces_root = snap.compute_root()?;
                 anchors.push(RootAnchor {
-                    root,
+                    spaces_root,
+                    ptrs_root: None,
                     block: anchor,
                 });
             }

--- a/client/tests/ptr_tests.rs
+++ b/client/tests/ptr_tests.rs
@@ -7,12 +7,11 @@ use spaces_client::{
     },
     wallets::{AddressKind, WalletResponse},
 };
-use spaces_client::rpc::{CommitParams, CreatePtrParams, TransferPtrParams, TransferSpacesParams};
+use spaces_client::rpc::{CommitParams, CreatePtrParams, DelegateParams, TransferPtrParams, TransferSpacesParams};
 use spaces_client::store::Sha256;
 use spaces_protocol::{bitcoin, bitcoin::{FeeRate}};
 use spaces_protocol::bitcoin::hashes::{sha256, Hash};
 use spaces_ptr::sptr::Sptr;
-use spaces_ptr::transcript_hash;
 use spaces_testutil::TestRig;
 use spaces_wallet::{export::WalletExport};
 use spaces_wallet::address::SpaceAddress;
@@ -21,270 +20,7 @@ const ALICE: &str = "wallet_99";
 const BOB: &str = "wallet_98";
 const EVE: &str = "wallet_93";
 
-async fn it_should_create_sptrs(rig: &TestRig) -> anyhow::Result<()> {
-    rig.wait_until_wallet_synced(ALICE).await?;
-
-    // 1) Create ptr bound to addr0 (spk0)
-    let addr0 = rig.spaced.client.wallet_get_new_address(ALICE, AddressKind::Coin).await?;
-    let addr0_spk = bitcoin::address::Address::from_str(&addr0)
-        .expect("valid").assume_checked()
-        .script_pubkey();
-    let addr0_spk_string = hex::encode(addr0_spk.as_bytes());
-
-    let create0 = wallet_do(
-        rig,
-        ALICE,
-        vec![RpcWalletRequest::CreatePtr(CreatePtrParams { spk: addr0_spk_string.clone() })],
-        false,
-    ).await.expect("CreatePtr addr0");
-    assert!(wallet_res_err(&create0).is_ok(), "CreatePtr(addr0) must not error");
-
-    rig.mine_blocks(1, None).await?;
-    rig.wait_until_synced().await?;
-    rig.wait_until_wallet_synced(ALICE).await?;
-
-    let spk0 = bitcoin::address::Address::from_str(&addr0)
-        .expect("valid addr0")
-        .assume_checked()
-        .script_pubkey();
-    let sptr0 = Sptr::from_spk::<Sha256>(spk0.clone());
-
-    let ptr0 = rig.spaced.client.get_ptr(sptr0).await?
-        .expect("ptr must exist after first CreatePtr");
-    let bound_spk_before = ptr0.ptrout.script_pubkey.clone();
-
-    // 2) Transfer ptr to addr1 (binding should change to spk1)
-    let addr1 = rig.spaced.client.wallet_get_new_address(BOB, AddressKind::Space).await?;
-    let xfer = wallet_do(
-        rig,
-        ALICE,
-        vec![RpcWalletRequest::TransferPtr(TransferPtrParams {
-            ptrs: vec![sptr0],
-            to: addr1.clone(),
-        })],
-        false,
-    ).await.expect("TransferPtr to addr1");
-    assert!(wallet_res_err(&xfer).is_ok(), "TransferPtr must not error");
-
-    rig.mine_blocks(1, None).await?;
-    rig.wait_until_wallet_synced(ALICE).await?;
-    rig.wait_until_wallet_synced(BOB).await?;
-    rig.wait_until_synced().await?;
-
-
-    let spk1 = SpaceAddress::from_str(&addr1)
-        .expect("valid addr1")
-        .script_pubkey();
-
-    let ptr_after_xfer = rig.spaced.client.get_ptr(sptr0).await?
-        .expect("ptr must still resolve after transfer");
-    let bound_spk_after = ptr_after_xfer.ptrout.script_pubkey.clone();
-
-    assert_ne!(bound_spk_before, bound_spk_after, "binding must change after transfer");
-    assert_eq!(bound_spk_after, spk1, "binding must equal new destination spk");
-
-    // 3) Duplicate CreatePtr on ORIGINAL addr0 → tx is produced but MUST NOT overwrite binding
-    let dup = wallet_do(
-        rig,
-        ALICE,
-        vec![RpcWalletRequest::CreatePtr(CreatePtrParams { spk: addr0_spk_string })],
-        false,
-    ).await.expect("duplicate CreatePtr(addr0)");
-    assert!(wallet_res_err(&dup).is_ok(), "duplicate CreatePtr should not error");
-    assert!(!dup.result.is_empty(), "protocol still emits a tx for duplicate CreatePtr");
-
-    rig.mine_blocks(1, None).await?;
-    rig.wait_until_synced().await?;
-    rig.wait_until_wallet_synced(ALICE).await?;
-
-    let ptr_after_dup = rig.spaced.client.get_ptr(sptr0).await?
-        .expect("ptr must still resolve after duplicate");
-    let bound_spk_final = ptr_after_dup.ptrout.script_pubkey.clone();
-
-    assert_eq!(
-        bound_spk_final, spk1,
-        "duplicate CreatePtr(addr0) must be ignored: binding stays at spk1"
-    );
-    assert_ne!(
-        bound_spk_final, spk0,
-        "binding must not be overwritten back to original spk0"
-    );
-
-    Ok(())
-}
-
-async fn it_should_operate_space(rig: &TestRig) -> anyhow::Result<()> {
-    rig.wait_until_synced().await?;
-    rig.wait_until_wallet_synced(ALICE).await?;
-
-    // Pick any space Alice already OWNS.
-    let alice_spaces = rig.spaced.client.wallet_list_spaces(ALICE).await?;
-    let owned = alice_spaces
-        .owned
-        .first()
-        .cloned()
-        .expect("Alice should own at least one space for this test");
-    let space_name = owned
-        .spaceout
-        .space
-        .as_ref()
-        .expect("space must exist")
-        .name
-        .to_string();
-
-    // Fetch full space and capture its current scriptPubKey (will be used for SPTR + address).
-    let full_before = rig
-        .spaced
-        .client
-        .get_space(&space_name)
-        .await?
-        .expect("space must exist");
-
-    let current_spk = full_before.spaceout.script_pubkey.clone();
-    let res = wallet_do(
-        rig,
-        ALICE,
-        vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![space_name.clone()],
-            to: None,
-        })],
-        false,
-    )
-        .await
-        .expect("send transfer-to-same-address (renewal)");
-
-    assert!(wallet_res_err(&res).is_ok(), "tx should not error");
-
-    // Confirm renewal.
-    rig.mine_blocks(1, None).await?;
-    rig.wait_until_synced().await?;
-    rig.wait_until_wallet_synced(ALICE).await?;
-
-    let full_after = rig
-        .spaced
-        .client
-        .get_space(&space_name)
-        .await?
-        .expect("space must still exist");
-    let spk_after = full_after.spaceout.script_pubkey.clone();
-
-    // Address/script must be identical after renewal.
-    assert_eq!(current_spk, spk_after, "space spk must remain the same after renewal");
-
-    // --- Create/bind an SPTR using the SAME scriptPubKey as the space ---
-    let create_ptr_res = wallet_do(
-        rig,
-        ALICE,
-        vec![RpcWalletRequest::CreatePtr(CreatePtrParams {
-            spk: hex::encode(current_spk.as_bytes()),
-        })],
-        false,
-    )
-        .await
-        .expect("send CreatePtr to space address");
-
-    assert!(wallet_res_err(&create_ptr_res).is_ok(), "CreatePtr tx should not error");
-
-
-    // Confirm ptr binding.
-    rig.mine_blocks(1, None).await?;
-    rig.wait_until_synced().await?;
-    rig.wait_until_wallet_synced(ALICE).await?;
-
-    // Compute SPTR from the (unchanged) space spk and verify it's indexed.
-    let sptr = Sptr::from_spk::<Sha256>(current_spk.clone());
-    let ptr_out = rig.spaced.client.get_ptr(sptr).await?;
-    assert!(ptr_out.is_some(), "ptr lookup by SPTR should return a result for the space spk");
-
-
-    let space = full_after.spaceout.space.expect("space");
-    let delegation = rig.spaced.client.get_delegation(space.name.clone()).await?;
-    assert_eq!(delegation, Some(sptr), "expected a delegation matching sptr");
-
-    let delegator = rig.spaced.client.get_delegator(sptr).await?;
-    assert_eq!(delegator, Some(space.name.clone()), "expected a delegator to match sptr");
-
-    let commitments_tip = rig.spaced.client.get_commitment(space.name.clone(), None)
-        .await.expect("commitment tip");
-    assert!(commitments_tip.is_none(), "no initial commitment was made");
-    
-    // Make a commitment
-    let create_commitment_res = wallet_do(
-        rig,
-        ALICE,
-        vec![RpcWalletRequest::Commit(CommitParams {
-            space: space.name.clone(),
-            root: sha256::Hash::from_slice(&[1u8;32]).expect("valid"),
-        })],
-        false,
-    )
-        .await
-        .expect("commits");
-
-    assert!(wallet_res_err(&create_commitment_res).is_ok(), "commit tx should not error");
-
-
-    // Confirm commitment.
-    rig.mine_blocks(1, None).await?;
-    rig.wait_until_synced().await?;
-    rig.wait_until_wallet_synced(ALICE).await?;
-
-    let commitments_tip = rig.spaced.client.get_commitment(space.name.clone(), None)
-        .await.expect("commitment tip");
-    assert!(commitments_tip.is_some(), "one commitment was made");
-    let commitment = commitments_tip.unwrap();
-
-    assert_eq!(commitment.state_root, [1u8;32], "there was a commitment");
-    assert!(commitment.prev_root.is_none(), "no previous root");
-    assert_eq!(commitment.history_hash, [1u8;32], "history hash must match initial commitment");
-
-
-    // Make another commitment
-    let create_commitment_res = wallet_do(
-        rig,
-        ALICE,
-        vec![RpcWalletRequest::Commit(CommitParams {
-            space: space.name.clone(),
-            root: sha256::Hash::from_slice(&[2u8;32]).expect("valid"),
-        })],
-        false,
-    )
-        .await
-        .expect("commits");
-
-    assert!(wallet_res_err(&create_commitment_res).is_ok(), "commit tx should not error");
-
-    // Confirm commitment.
-    rig.mine_blocks(1, None).await?;
-    rig.wait_until_synced().await?;
-    rig.wait_until_wallet_synced(ALICE).await?;
-
-    let commitments_tip = rig.spaced.client.get_commitment(space.name.clone(), None)
-        .await.expect("commitment tip");
-    let commitment = commitments_tip.unwrap();
-
-    assert_eq!(commitment.state_root, [2u8;32], "tip must point to most recent commitment");
-    assert_eq!(commitment.prev_root.clone(), Some([1u8;32]) , "prev should point to preview commitment");
-    assert_eq!(commitment.history_hash, transcript_hash::<Sha256>([1u8;32], [2u8;32]),
-               "history hash must commit to all commitments");
-
-
-    let prev_commit =
-        rig.spaced.client.get_commitment(
-            space.name.clone(),
-            Some(sha256::Hash::from_slice(
-                commitment.prev_root.as_ref().expect("exists")
-            ).expect("valid"))
-        ).await.expect("prev_commitment");
-
-    assert_eq!(
-        prev_commit.map(|p| p.state_root),
-        Some([1u8;32]),
-        "previous commitment should continue to exist"
-    );
-
-    Ok(())
-}
+// ============== Helper Functions ==============
 
 fn wallet_res_err(res: &WalletResponse) -> anyhow::Result<()> {
     for tx in &res.result {
@@ -296,27 +32,6 @@ fn wallet_res_err(res: &WalletResponse) -> anyhow::Result<()> {
             return Err(anyhow!("{}", s));
         }
     }
-    Ok(())
-}
-
-#[tokio::test]
-async fn run_ptr_tests() -> anyhow::Result<()> {
-    let rig = TestRig::new_with_regtest_preset().await?;
-    let wallets_path = rig.testdata_wallets_path().await;
-
-    let count = rig.get_block_count().await? as u32;
-    assert!(count > 3000, "expected an initialized test set");
-
-    rig.wait_until_synced().await?;
-    load_wallet(&rig, wallets_path.clone(), ALICE).await?;
-    load_wallet(&rig, wallets_path.clone(), BOB).await?;
-    load_wallet(&rig, wallets_path, EVE).await?;
-
-    it_should_create_sptrs(&rig)
-        .await
-        .expect("should open auction");
-
-    it_should_operate_space(&rig).await.expect("should operate space");
     Ok(())
 }
 
@@ -351,4 +66,728 @@ async fn wallet_do(
         )
         .await?;
     Ok(res)
+}
+
+async fn sync_all(rig: &TestRig) -> anyhow::Result<()> {
+    rig.wait_until_synced().await?;
+    rig.wait_until_wallet_synced(ALICE).await?;
+    rig.wait_until_wallet_synced(BOB).await?;
+    Ok(())
+}
+
+async fn mine_and_sync(rig: &TestRig, blocks: usize) -> anyhow::Result<()> {
+    rig.mine_blocks(blocks, None).await?;
+    sync_all(rig).await
+}
+
+// ============== Test: Basic SPTR Creation ==============
+
+async fn it_should_create_sptrs(rig: &TestRig) -> anyhow::Result<()> {
+    rig.wait_until_wallet_synced(ALICE).await?;
+
+    // Create ptr bound to addr0
+    let addr0 = rig.spaced.client.wallet_get_new_address(ALICE, AddressKind::Coin).await?;
+    let addr0_spk = bitcoin::address::Address::from_str(&addr0)
+        .expect("valid").assume_checked()
+        .script_pubkey();
+    let addr0_spk_string = hex::encode(addr0_spk.as_bytes());
+
+    let create0 = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::CreatePtr(CreatePtrParams { spk: addr0_spk_string.clone() })],
+        false,
+    ).await.expect("CreatePtr addr0");
+    assert!(wallet_res_err(&create0).is_ok(), "CreatePtr(addr0) must not error");
+
+    mine_and_sync(rig, 1).await?;
+
+    let spk0 = bitcoin::address::Address::from_str(&addr0)
+        .expect("valid addr0")
+        .assume_checked()
+        .script_pubkey();
+    let sptr0 = Sptr::from_spk::<Sha256>(spk0.clone());
+
+    let ptr0 = rig.spaced.client.get_ptr(sptr0).await?
+        .expect("ptr must exist after first CreatePtr");
+    let bound_spk_before = ptr0.ptrout.script_pubkey.clone();
+
+    // Transfer ptr to addr1 (binding should change)
+    let addr1 = rig.spaced.client.wallet_get_new_address(BOB, AddressKind::Space).await?;
+    let xfer = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::TransferPtr(TransferPtrParams {
+            ptrs: vec![sptr0],
+            to: addr1.clone(),
+        })],
+        false,
+    ).await.expect("TransferPtr to addr1");
+    assert!(wallet_res_err(&xfer).is_ok(), "TransferPtr must not error");
+
+    mine_and_sync(rig, 1).await?;
+
+    let spk1 = SpaceAddress::from_str(&addr1)
+        .expect("valid addr1")
+        .script_pubkey();
+
+    let ptr_after_xfer = rig.spaced.client.get_ptr(sptr0).await?
+        .expect("ptr must still resolve after transfer");
+    let bound_spk_after = ptr_after_xfer.ptrout.script_pubkey.clone();
+
+    assert_ne!(bound_spk_before, bound_spk_after, "binding must change after transfer");
+    assert_eq!(bound_spk_after, spk1, "binding must equal new destination spk");
+
+    // Duplicate CreatePtr on ORIGINAL addr0 → should be ignored
+    let dup = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::CreatePtr(CreatePtrParams { spk: addr0_spk_string })],
+        true,
+    ).await.expect("duplicate CreatePtr(addr0)");
+    assert!(wallet_res_err(&dup).is_ok(), "duplicate CreatePtr should not error");
+
+    mine_and_sync(rig, 1).await?;
+
+    let ptr_after_dup = rig.spaced.client.get_ptr(sptr0).await?
+        .expect("ptr must still resolve after duplicate");
+    let bound_spk_final = ptr_after_dup.ptrout.script_pubkey.clone();
+
+    assert_eq!(bound_spk_final, spk1, "duplicate CreatePtr must be ignored");
+    assert_ne!(bound_spk_final, spk0, "binding must not revert to original");
+
+    Ok(())
+}
+
+// ============== Test: Basic Commitments with Rollback ==============
+
+async fn it_should_commit_and_rollback(rig: &TestRig) -> anyhow::Result<()> {
+    sync_all(rig).await?;
+
+    // Get a space that Alice owns
+    let alice_spaces = rig.spaced.client.wallet_list_spaces(ALICE).await?;
+    let owned = alice_spaces.owned.first().cloned()
+        .expect("Alice should own at least one space");
+    let space_name = owned.spaceout.space.as_ref()
+        .expect("space must exist").name.clone();
+
+    // Setup: Delegate the space to establish SPTR
+    let delegate = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Delegate(DelegateParams {
+            space: space_name.clone(),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&delegate).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Verify delegation is set up
+    let sptr = rig.spaced.client.get_delegation(space_name.clone()).await?
+        .expect("delegation should be established");
+
+    // Test 1: Make initial commitment [1u8;32]
+    println!("Creating initial commitment [1u8;32]...");
+    let commit1 = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Commit(CommitParams {
+            space: space_name.clone(),
+            root: Some(sha256::Hash::from_slice(&[1u8;32]).expect("valid")),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&commit1).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    let tip = rig.spaced.client.get_commitment(space_name.clone(), None).await?
+        .expect("commitment should exist");
+    assert_eq!(tip.state_root, [1u8;32]);
+    assert_eq!(tip.prev_root, None);
+
+    // Test 2: Rollback pending commitment
+    println!("Rolling back pending commitment [1u8;32]...");
+    let rollback = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Commit(CommitParams {
+            space: space_name.clone(),
+            root: None, // None = rollback
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&rollback).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    let tip_after_rollback = rig.spaced.client.get_commitment(space_name.clone(), None).await?;
+    assert_eq!(tip_after_rollback, None, "commitment should be rolled back");
+
+    // Test 3: Create new commitment and finalize it
+    println!("Creating commitment [2u8;32] and finalizing...");
+    let commit2 = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Commit(CommitParams {
+            space: space_name.clone(),
+            root: Some(sha256::Hash::from_slice(&[2u8;32]).expect("valid")),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&commit2).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Finalize by mining 144 blocks
+    println!("Mining 144 blocks to finalize [2u8;32]...");
+    mine_and_sync(rig, 144).await?;
+
+    // Test 4: Try to rollback finalized commitment (should fail/no-op)
+    println!("Attempting to rollback finalized commitment...");
+    let rollback_finalized = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Commit(CommitParams {
+            space: space_name.clone(),
+            root: None, // Rollback attempt
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&rollback_finalized).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    let tip_after_failed_rollback = rig.spaced.client.get_commitment(space_name.clone(), None).await?
+        .expect("finalized commitment should still exist");
+    assert_eq!(tip_after_failed_rollback.state_root, [2u8;32],
+               "finalized commitment should not be rolled back");
+
+    // Test 5: Add new commitment on top of finalized
+    println!("Adding [3u8;32] on top of finalized [2u8;32]...");
+    let commit3 = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Commit(CommitParams {
+            space: space_name.clone(),
+            root: Some(sha256::Hash::from_slice(&[3u8;32]).expect("valid")),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&commit3).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    let tip_final = rig.spaced.client.get_commitment(space_name.clone(), None).await?
+        .expect("new commitment should exist");
+    assert_eq!(tip_final.state_root, [3u8;32]);
+    assert_eq!(tip_final.prev_root, Some([2u8;32]));
+
+    // Verify finalized [2u8;32] still exists
+    let finalized = rig.spaced.client.get_commitment(
+        space_name.clone(),
+        Some(sha256::Hash::from_slice(&[2u8;32]).expect("valid"))
+    ).await?.expect("finalized commitment should be preserved");
+    assert_eq!(finalized.state_root, [2u8;32]);
+
+    Ok(())
+}
+
+// ============== Test: Multiple Commitments in Single Transaction ==============
+
+async fn it_should_handle_multiple_commitments(rig: &TestRig) -> anyhow::Result<()> {
+    sync_all(rig).await?;
+
+    // Get two spaces that Alice owns
+    let alice_spaces = rig.spaced.client.wallet_list_spaces(ALICE).await?;
+    assert!(alice_spaces.owned.len() >= 2, "Alice needs at least 2 spaces for this test");
+
+    let space1_name = alice_spaces.owned[0].spaceout.space.as_ref()
+        .expect("space must exist").name.clone();
+    let space2_name = alice_spaces.owned[1].spaceout.space.as_ref()
+        .expect("space must exist").name.clone();
+
+    // Setup: Delegate both spaces to establish SPTRs
+    for space_name in [&space1_name, &space2_name] {
+        let delegate = wallet_do(
+            rig,
+            ALICE,
+            vec![RpcWalletRequest::Delegate(DelegateParams {
+                space: space_name.clone(),
+            })],
+            false,
+        ).await?;
+        assert!(wallet_res_err(&delegate).is_ok());
+    }
+    mine_and_sync(rig, 1).await?;
+
+    // Verify both delegations exist
+    let sptr1 = rig.spaced.client.get_delegation(space1_name.clone()).await?
+        .expect("space1 should have delegation");
+    let sptr2 = rig.spaced.client.get_delegation(space2_name.clone()).await?
+        .expect("space2 should have delegation");
+
+    println!("Space 1: {} -> SPTR: {}", space1_name, sptr1);
+    println!("Space 2: {} -> SPTR: {}", space2_name, sptr2);
+
+    // Verify delegations match delegator
+    let delegator1 = rig.spaced.client.get_delegator(sptr1).await?
+        .expect("sptr1 delegator should exist");
+    let delegator2 = rig.spaced.client.get_delegator(sptr2).await?
+        .expect("sptr2 delegator should exist");
+
+    assert_eq!(delegator1.to_string(), space1_name.to_string(), "space 1 delegators dont match");
+    assert_eq!(delegator2.to_string(), space2_name.to_string(), "space 2 delegators dont match");
+
+
+    // Test 1: Submit two commitments in one transaction
+    println!("Submitting 2 commitments in single transaction...");
+    let multi_commit = wallet_do(
+        rig,
+        ALICE,
+        vec![
+            RpcWalletRequest::Commit(CommitParams {
+                space: space1_name.clone(),
+                root: Some(sha256::Hash::from_slice(&[10u8;32]).expect("valid")),
+            }),
+            RpcWalletRequest::Commit(CommitParams {
+                space: space2_name.clone(),
+                root: Some(sha256::Hash::from_slice(&[20u8;32]).expect("valid")),
+            }),
+        ],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&multi_commit).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Verify both commitments were created
+    let commit2 = rig.spaced.client.get_commitment(space2_name.clone(), None).await?
+        .expect("space2 should have commitment");
+    let commit1 = rig.spaced.client.get_commitment(space1_name.clone(), None).await?
+        .expect("space1 should have commitment");
+
+
+    assert_eq!(commit1.state_root, [10u8;32], "space1 commitment");
+    assert_eq!(commit2.state_root, [20u8;32], "space2 commitment");
+
+    // Test 2: Rollback both in single transaction
+    println!("Rolling back both commitments in single transaction...");
+    let multi_rollback = wallet_do(
+        rig,
+        ALICE,
+        vec![
+            RpcWalletRequest::Commit(CommitParams {
+                space: space1_name.clone(),
+                root: None, // rollback
+            }),
+            RpcWalletRequest::Commit(CommitParams {
+                space: space2_name.clone(),
+                root: None, // rollback
+            }),
+        ],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&multi_rollback).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Verify both were rolled back
+    let commit1_after = rig.spaced.client.get_commitment(space1_name.clone(), None).await?;
+    let commit2_after = rig.spaced.client.get_commitment(space2_name.clone(), None).await?;
+
+    assert_eq!(commit1_after, None, "space1 should be rolled back");
+    assert_eq!(commit2_after, None, "space2 should be rolled back");
+
+    // Test 3: Mixed operations - commit one, keep other unchanged
+    println!("Mixed operation: new commitment for space1 only...");
+    let mixed = wallet_do(
+        rig,
+        ALICE,
+        vec![
+            RpcWalletRequest::Commit(CommitParams {
+                space: space1_name.clone(),
+                root: Some(sha256::Hash::from_slice(&[30u8;32]).expect("valid")),
+            }),
+        ],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&mixed).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    let commit1_final = rig.spaced.client.get_commitment(space1_name.clone(), None).await?
+        .expect("space1 should have new commitment");
+    let commit2_final = rig.spaced.client.get_commitment(space2_name.clone(), None).await?;
+
+    assert_eq!(commit1_final.state_root, [30u8;32], "space1 updated");
+    assert_eq!(commit2_final, None, "space2 unchanged");
+
+    Ok(())
+}
+
+// ============== Test: Commitment Override Within 144 Blocks ==============
+
+async fn it_should_override_pending_commitments(rig: &TestRig) -> anyhow::Result<()> {
+    sync_all(rig).await?;
+
+    let alice_spaces = rig.spaced.client.wallet_list_spaces(ALICE).await?;
+    let space_name = alice_spaces.owned[0].spaceout.space.as_ref()
+        .expect("space must exist").name.clone();
+
+    // Setup: Delegate the space to establish SPTR
+    let delegate = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Delegate(DelegateParams {
+            space: space_name.clone(),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&delegate).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Make commitment [1u8;32]
+    println!("Creating commitment [1u8;32]...");
+    let commit1 = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Commit(CommitParams {
+            space: space_name.clone(),
+            root: Some(sha256::Hash::from_slice(&[1u8;32]).expect("valid")),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&commit1).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Override with [2u8;32] while still pending
+    println!("Overriding with [2u8;32] while pending...");
+    let commit2 = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Commit(CommitParams {
+            space: space_name.clone(),
+            root: Some(sha256::Hash::from_slice(&[2u8;32]).expect("valid")),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&commit2).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Verify [1u8;32] is gone, [2u8;32] is tip
+    let old_commit = rig.spaced.client.get_commitment(
+        space_name.clone(),
+        Some(sha256::Hash::from_slice(&[1u8;32]).expect("valid"))
+    ).await?;
+    assert_eq!(old_commit, None, "[1u8;32] should be overridden");
+
+    let tip = rig.spaced.client.get_commitment(space_name.clone(), None).await?
+        .expect("tip should exist");
+    assert_eq!(tip.state_root, [2u8;32]);
+    assert_eq!(tip.prev_root, None, "no previous since [1u8;32] was overridden");
+
+    // Finalize [2u8;32]
+    println!("Finalizing [2u8;32]...");
+    mine_and_sync(rig, 144).await?;
+
+    // Try to override finalized [2u8;32] with [3u8;32] - should chain instead
+    println!("Adding [3u8;32] on top of finalized [2u8;32]...");
+    let commit3 = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Commit(CommitParams {
+            space: space_name.clone(),
+            root: Some(sha256::Hash::from_slice(&[3u8;32]).expect("valid")),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&commit3).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Verify [2u8;32] still exists and [3u8;32] chains from it
+    let finalized = rig.spaced.client.get_commitment(
+        space_name.clone(),
+        Some(sha256::Hash::from_slice(&[2u8;32]).expect("valid"))
+    ).await?.expect("[2u8;32] should still exist");
+    assert_eq!(finalized.state_root, [2u8;32]);
+
+    let new_tip = rig.spaced.client.get_commitment(space_name.clone(), None).await?
+        .expect("new tip should exist");
+    assert_eq!(new_tip.state_root, [3u8;32]);
+    assert_eq!(new_tip.prev_root, Some([2u8;32]));
+
+    Ok(())
+}
+
+async fn it_should_reject_duplicate_sptr_delegations(rig: &TestRig) -> anyhow::Result<()> {
+    sync_all(rig).await?;
+
+    // Get two spaces that Alice owns
+    let alice_spaces = rig.spaced.client.wallet_list_spaces(ALICE).await?;
+    assert!(alice_spaces.owned.len() >= 2, "Alice needs at least 2 spaces for this test");
+
+    let space1_name = alice_spaces.owned[0].spaceout.space.as_ref()
+        .expect("space must exist").name.clone();
+    let space2_name = alice_spaces.owned[1].spaceout.space.as_ref()
+        .expect("space must exist").name.clone();
+
+    println!("Testing SPTR uniqueness with {} and {}", space1_name, space2_name);
+
+    // Get a common address to create the same SPTR
+    let common_addr = rig.spaced.client.wallet_get_new_address(ALICE, AddressKind::Space).await?;
+    let common_spk = SpaceAddress::from_str(&common_addr)
+        .expect("valid space address")
+        .script_pubkey();
+    let common_sptr = Sptr::from_spk::<Sha256>(common_spk.clone());
+
+    println!("Common address: {}", common_addr);
+    println!("Expected SPTR: {}", common_sptr);
+
+    // Transfer space1 to the common address
+    println!("Transferring {} to common address...", space1_name);
+    let transfer1 = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Transfer(TransferSpacesParams {
+            spaces: vec![space1_name.to_string()],
+            to: Some(common_addr.clone()),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&transfer1).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Verify the reverse mapping: SPTR -> space1
+    let delegator1 = rig.spaced.client.get_delegator(common_sptr).await?
+        .expect("common SPTR should have delegator");
+    assert_eq!(delegator1, space1_name, "common SPTR should point to space1");
+
+    println!("✓ Space1 successfully claimed SPTR {} (reverse mapping: {} -> {})",
+        common_sptr, common_sptr, space1_name);
+
+    // Transfer space2 to the SAME address (same SPTR)
+    println!("Transferring {} to the same address (attempting to claim same SPTR)...", space2_name);
+    let transfer2 = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Transfer(TransferSpacesParams {
+            spaces: vec![space2_name.to_string()],
+            to: Some(common_addr.clone()),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&transfer2).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Key test: Verify the reverse mapping was NOT overwritten
+    // The SPTR should still point to space1, not space2
+    let delegator_after = rig.spaced.client.get_delegator(common_sptr).await?
+        .expect("common SPTR should still have delegator");
+    assert_eq!(delegator_after, space1_name,
+        "CRITICAL: common SPTR should still point to space1 (not overwritten by space2)");
+
+    println!("✓ Space2 correctly rejected - reverse mapping preserved ({} -> {})",
+        common_sptr, space1_name);
+
+    // Note: get_delegation for both spaces will return Some(common_sptr) because
+    // both are at the same address, but only space1 actually owns the delegation
+
+    // Transfer space1 away to free up the SPTR
+    println!("Moving {} away to free up SPTR...", space1_name);
+    let new_addr = rig.spaced.client.wallet_get_new_address(ALICE, AddressKind::Space).await?;
+    let transfer_away = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Transfer(TransferSpacesParams {
+            spaces: vec![space1_name.to_string()],
+            to: Some(new_addr),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&transfer_away).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Verify common_sptr is now free (reverse mapping removed)
+    let delegator_freed = rig.spaced.client.get_delegator(common_sptr).await?;
+    assert_eq!(delegator_freed, None, "common SPTR should be free (no reverse mapping) after space1 moved");
+
+    println!("✓ SPTR freed - reverse mapping removed");
+
+    // Now space2 should be able to claim it if we transfer it back
+    println!("Re-transferring {} to now-free SPTR...", space2_name);
+    let transfer2_retry = wallet_do(
+        rig,
+        ALICE,
+        vec![RpcWalletRequest::Transfer(TransferSpacesParams {
+            spaces: vec![space2_name.to_string()],
+            to: Some(common_addr),
+        })],
+        false,
+    ).await?;
+    assert!(wallet_res_err(&transfer2_retry).is_ok());
+    mine_and_sync(rig, 1).await?;
+
+    // Verify space2 now owns the reverse mapping
+    let delegator2_retry = rig.spaced.client.get_delegator(common_sptr).await?
+        .expect("common SPTR should have delegator");
+    assert_eq!(delegator2_retry, space2_name,
+        "common SPTR should now point to space2 (reverse mapping updated)");
+
+    println!("✓ Space2 successfully claimed SPTR after it was freed ({} -> {})",
+        common_sptr, space2_name);
+
+    Ok(())
+}
+
+// ============== Main Test Runner ==============
+
+#[tokio::test]
+async fn run_ptr_tests() -> anyhow::Result<()> {
+    let rig = TestRig::new_with_regtest_preset().await?;
+    let wallets_path = rig.testdata_wallets_path().await;
+
+    let count = rig.get_block_count().await? as u32;
+    assert!(count > 3000, "expected an initialized test set");
+
+    rig.wait_until_synced().await?;
+    load_wallet(&rig, wallets_path.clone(), ALICE).await?;
+    load_wallet(&rig, wallets_path.clone(), BOB).await?;
+    load_wallet(&rig, wallets_path, EVE).await?;
+
+    println!("\n=== Running SPTR Creation Tests ===");
+    it_should_create_sptrs(&rig).await?;
+
+    println!("\n=== Running SPTR Uniqueness Tests ===");
+    it_should_reject_duplicate_sptr_delegations(&rig).await?;
+
+    println!("\n=== Running Commitment & Rollback Tests ===");
+    it_should_commit_and_rollback(&rig).await?;
+
+    println!("\n=== Running Multiple Commitment Tests ===");
+    it_should_handle_multiple_commitments(&rig).await?;
+
+    println!("\n=== Running Pending Override Tests ===");
+    it_should_override_pending_commitments(&rig).await?;
+
+    println!("\n=== Running PTR n→n Transfer Rule Tests ===");
+    it_should_transfer_ptr_with_n_to_n_rule(&rig).await?;
+
+    println!("\n=== All tests passed! ===");
+    Ok(())
+}
+
+// ============== Test: PTR n→n Transfer Rule ==============
+
+async fn it_should_transfer_ptr_with_n_to_n_rule(rig: &TestRig) -> anyhow::Result<()> {
+    sync_all(rig).await?;
+
+    // Test 1: Basic n→n transfer (same value, key rotation)
+    println!("Test 1: n→n transfer (same value)");
+    {
+        // Create a PTR
+        let addr0 = rig.spaced.client.wallet_get_new_address(ALICE, AddressKind::Coin).await?;
+        let addr0_spk = bitcoin::address::Address::from_str(&addr0)?.assume_checked().script_pubkey();
+        let addr0_spk_string = hex::encode(addr0_spk.as_bytes());
+
+        wallet_do(rig, ALICE, vec![
+            RpcWalletRequest::CreatePtr(CreatePtrParams { spk: addr0_spk_string })
+        ], false).await?;
+        mine_and_sync(rig, 1).await?;
+
+        let sptr = Sptr::from_spk::<Sha256>(addr0_spk.clone());
+        let ptr_before = rig.spaced.client.get_ptr(sptr).await?.expect("ptr must exist");
+        let value_before = ptr_before.ptrout.value;
+
+        // Transfer to addr1 with SAME value (should use n→n rule)
+        let addr1 = rig.spaced.client.wallet_get_new_address(BOB, AddressKind::Space).await?;
+        wallet_do(rig, ALICE, vec![
+            RpcWalletRequest::TransferPtr(TransferPtrParams {
+                ptrs: vec![sptr],
+                to: addr1.clone(),
+            })
+        ], false).await?;
+        mine_and_sync(rig, 1).await?;
+
+        let ptr_after = rig.spaced.client.get_ptr(sptr).await?.expect("ptr must still exist");
+        let spk1 = SpaceAddress::from_str(&addr1)?.script_pubkey();
+
+        assert_eq!(ptr_after.ptrout.script_pubkey, spk1, "PTR should transfer to new address");
+        assert_eq!(ptr_after.ptrout.value, value_before, "PTR value should remain same (n→n)");
+        println!("✓ n→n transfer successful (same value preserved)");
+    }
+
+    // Test 2: Multiple PTR transfers in same transaction
+    println!("\nTest 2: Multiple PTR transfers in same tx");
+    {
+        // Create two PTRs
+        let addr_a = rig.spaced.client.wallet_get_new_address(ALICE, AddressKind::Coin).await?;
+        let addr_b = rig.spaced.client.wallet_get_new_address(ALICE, AddressKind::Coin).await?;
+        let spk_a = bitcoin::address::Address::from_str(&addr_a)?.assume_checked().script_pubkey();
+        let spk_b = bitcoin::address::Address::from_str(&addr_b)?.assume_checked().script_pubkey();
+
+        wallet_do(rig, ALICE, vec![
+            RpcWalletRequest::CreatePtr(CreatePtrParams { spk: hex::encode(spk_a.as_bytes()) }),
+            RpcWalletRequest::CreatePtr(CreatePtrParams { spk: hex::encode(spk_b.as_bytes()) }),
+        ], false).await?;
+        mine_and_sync(rig, 1).await?;
+
+        let sptr_a = Sptr::from_spk::<Sha256>(spk_a.clone());
+        let sptr_b = Sptr::from_spk::<Sha256>(spk_b.clone());
+
+        // Transfer both to different addresses
+        let dest_a = rig.spaced.client.wallet_get_new_address(BOB, AddressKind::Space).await?;
+        let dest_b = rig.spaced.client.wallet_get_new_address(BOB, AddressKind::Space).await?;
+
+        wallet_do(rig, ALICE, vec![
+            RpcWalletRequest::TransferPtr(TransferPtrParams { ptrs: vec![sptr_a], to: dest_a.clone() }),
+            RpcWalletRequest::TransferPtr(TransferPtrParams { ptrs: vec![sptr_b], to: dest_b.clone() }),
+        ], false).await?;
+        mine_and_sync(rig, 1).await?;
+
+        let ptr_a_after = rig.spaced.client.get_ptr(sptr_a).await?.expect("ptr_a must exist");
+        let ptr_b_after = rig.spaced.client.get_ptr(sptr_b).await?.expect("ptr_b must exist");
+        let spk_dest_a = SpaceAddress::from_str(&dest_a)?.script_pubkey();
+        let spk_dest_b = SpaceAddress::from_str(&dest_b)?.script_pubkey();
+
+        assert_eq!(ptr_a_after.ptrout.script_pubkey, spk_dest_a, "PTR A should transfer correctly");
+        assert_eq!(ptr_b_after.ptrout.script_pubkey, spk_dest_b, "PTR B should transfer correctly");
+        println!("✓ Multiple PTR transfers handled correctly");
+    }
+
+    // Test 3: Commitment preserves n→n rule (same value)
+    println!("\nTest 3: Commitment uses n→n (same value preserved)");
+    {
+        // Get a space and delegate it
+        let alice_spaces = rig.spaced.client.wallet_list_spaces(ALICE).await?;
+        let space = alice_spaces.owned.first().expect("Alice should own a space").clone();
+        let space_name = space.spaceout.space.as_ref().expect("space").name.clone();
+
+        // Delegate to create PTR
+        wallet_do(rig, ALICE, vec![
+            RpcWalletRequest::Delegate(DelegateParams { space: space_name.clone() })
+        ], false).await?;
+        mine_and_sync(rig, 1).await?;
+
+        let sptr = rig.spaced.client.get_delegation(space_name.clone()).await?
+            .expect("delegation should exist");
+        let ptr_before_commit = rig.spaced.client.get_ptr(sptr).await?.expect("ptr must exist");
+        let value_before = ptr_before_commit.ptrout.value;
+        let spk_before = ptr_before_commit.ptrout.script_pubkey.clone();
+
+        // Make a commitment (should preserve value via n→n)
+        wallet_do(rig, ALICE, vec![
+            RpcWalletRequest::Commit(CommitParams {
+                space: space_name.clone(),
+                root: Some(sha256::Hash::from_slice(&[1u8; 32])?),
+            })
+        ], false).await?;
+        mine_and_sync(rig, 1).await?;
+
+        let ptr_after_commit = rig.spaced.client.get_ptr(sptr).await?.expect("ptr must exist after commit");
+
+        assert_eq!(ptr_after_commit.ptrout.value, value_before, "Commitment should preserve PTR value (n→n)");
+        assert_eq!(ptr_after_commit.ptrout.script_pubkey, spk_before, "Commitment should keep same address");
+
+        // Verify commitment was created
+        let commitment = rig.spaced.client.get_commitment(space_name.clone(), None).await?
+            .expect("commitment should exist");
+        assert_eq!(commitment.state_root, [1u8; 32], "Commitment root should match");
+        println!("✓ Commitment preserves PTR value and address (n→n rule)");
+    }
+
+    Ok(())
 }

--- a/ptr/Cargo.toml
+++ b/ptr/Cargo.toml
@@ -12,6 +12,7 @@ spaces_protocol = {path = "../protocol"}
 bincode = { version = "2.0.1", features = [ "derive", "serde", "alloc" ], default-features = false, optional = true }
 serde = { version = "^1.0", features = ["derive"], default-features = false, optional = true }
 bech32 = { version = "0.11.0", optional = true }
+hex = { version = "0.4", optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"
@@ -19,7 +20,7 @@ serde_json = "1.0.132"
 
 [features]
 default = ["std"]
-serde = ["dep:serde"]
+serde = ["dep:serde", "dep:hex"]
 bincode = ["dep:bincode"]
 bech32 = ["dep:bech32"]
 std = ["serde", "bincode", "bech32"]

--- a/ptr/src/constants.rs
+++ b/ptr/src/constants.rs
@@ -4,6 +4,8 @@ pub const PTR_MAINNET_HEIGHT : u32 = 922_777;
 pub const PTR_TESTNET4_HEIGHT : u32 = 100_008;
 pub const PTR_REGTEST_HEIGHT : u32 = 0;
 
+pub const COMMITMENT_FINALITY_INTERVAL : u32 = 144;
+
 pub fn ptrs_start_height(network: &Network) -> u32 {
     match network {
         Network::Bitcoin => PTR_MAINNET_HEIGHT,

--- a/ptr/src/lib.rs
+++ b/ptr/src/lib.rs
@@ -679,12 +679,8 @@ pub fn parse_ptr_op(tx: &Transaction) -> Option<PtrOp> {
                     Some(PtrOp::Commitment(CommitmentOp::Commit(commitments)))
                 }
                 x if x == PtrOpType::Data as u8 => {
-                    // Data: marker + payload
+                    // Data: marker + payload (payload can be empty)
                     let payload = &bytes[1..];
-                    if payload.is_empty() {
-                        return None;
-                    }
-
                     Some(PtrOp::Data(payload.as_bytes().to_vec()))
                 }
                 _ => None,

--- a/ptr/src/lib.rs
+++ b/ptr/src/lib.rs
@@ -104,6 +104,7 @@ pub struct PtrOut {
 pub struct Ptr {
     pub id: Sptr,
     pub data: Option<Vec<u8>>,
+    pub last_update: u32,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -499,7 +500,7 @@ impl Validator {
             }
             // Process spend
             changeset.spends.push(input_ctx.n);
-            self.process_spend(tx, input_ctx.n, input_ctx.ptrout, &new_space_utxos, &mut changeset);
+            self.process_spend(tx, input_ctx.n, input_ctx.ptrout, &new_space_utxos, &mut changeset, height);
         }
 
         // Process new PTR outputs
@@ -523,6 +524,7 @@ impl Validator {
                 sptr: Some(Ptr {
                     id: Sptr::from_spk::<H>(output.script_pubkey.clone()),
                     data: None,
+                    last_update: height,
                 }),
                 value: output.value,
                 script_pubkey: output.script_pubkey.clone(),
@@ -539,8 +541,9 @@ impl Validator {
         mut ptrout: PtrOut,
         new_space_utxos: &Vec<SpaceOut>,
         changeset: &mut TxChangeSet,
+        height: u32,
     ) {
-        let ptr = match ptrout.sptr {
+        let mut ptr = match ptrout.sptr {
             None => return,
             Some(ptr) => ptr,
         };
@@ -566,6 +569,7 @@ impl Validator {
             return;
         }
 
+        ptr.last_update = height;
         ptrout.n = output_index;
         ptrout.value = output.value;
         ptrout.script_pubkey = output.script_pubkey.clone();

--- a/ptr/src/sptr.rs
+++ b/ptr/src/sptr.rs
@@ -69,6 +69,32 @@ impl<'de> serde::Deserialize<'de> for Sptr {
     }
 }
 
+#[cfg(feature = "bincode")]
+mod bincode_impl {
+    use bincode::{
+        de::{Decoder},
+        enc::Encoder,
+        error::{DecodeError, EncodeError},
+        impl_borrow_decode, Decode, Encode,
+    };
+    use super::*;
+
+    impl Encode for Sptr {
+        fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+            Encode::encode(&self.0, encoder)
+        }
+    }
+
+    impl<Context> Decode<Context> for Sptr {
+        fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+            let bytes: [u8; 32] = Decode::decode(decoder)?;
+            Ok(Sptr(bytes))
+        }
+    }
+
+    impl_borrow_decode!(Sptr);
+}
+
 impl From<bech32::DecodeError> for SptrParseError {
     fn from(e: bech32::DecodeError) -> Self { SptrParseError::Bech32(e) }
 }

--- a/veritas/Cargo.toml
+++ b/veritas/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 spaces_protocol = { path = "../protocol", default-features = false, features = ["std"]}
+spaces_ptr = { path = "../ptr", default-features = false, features = ["std"]}
 bincode = { version = "2.0.1", default-features = false, features = ["alloc"]}
 spacedb = { git = "https://github.com/spacesprotocol/spacedb", version = "0.0.7", default-features = false }
 

--- a/veritas/README.md
+++ b/veritas/README.md
@@ -17,12 +17,12 @@ Veritas is a <strong>stateless way</strong> to verify <strong><a href="https://s
 
 ---
 
-## Javascript Example
+## Javascript Examples
 
-### Verifying proofs
+### Verifying Spaces proofs
 
 ```javascript
-const veritas = new Veritas();
+const veritas = new Veritas("spaces");
 
 // Set up a trust anchor
 const root = Buffer.from(
@@ -47,10 +47,10 @@ for (const {key, value: utxo} of proof.entries()) {
 }
 ```
 
-### Verifying messages
+### Verifying Spaces messages
 
 ```javascript
-const veritas = new Veritas();
+const veritas = new Veritas("spaces");
 
 // Set up a trust anchor
 const anchor = Buffer.from(
@@ -84,6 +84,55 @@ console.log("✅ Verified message:", msg.toString("utf-8"));
 console.log("- Signed by: ", space.toString());
 console.log("- Public Key:", Buffer.from(utxo.getPublicKey()).toString("hex"));
 console.log("- Signature: ", sig.toString('hex'));
+```
+
+### Verifying PTR proofs
+
+```javascript
+const veritas = new Veritas("ptrs");
+
+// Set up a PTR trust anchor
+const root = Buffer.from(
+    "b55cd9bda4295a18d75f79c9d60efcd78ee2cdf661b0df4b054ff7602bc70794",
+    "hex"
+);
+veritas.addAnchor(root);
+
+const rawProof = Buffer.from(
+    "...", // PTR proof bytes
+    "base64"
+);
+
+// Verify a PTR proof
+const proof = veritas.verifyProof(rawProof);
+
+// Find a PTR by its identifier
+const sptr = new Sptr("sptr1...");
+const ptrout = proof.findPtr(sptr);
+if (ptrout) {
+    console.log('✅ SPTR found');
+    console.log('🔑 Public key: ', Buffer.from(ptrout.getPublicKey()).toString('hex'));
+    const ptr = ptrout.getPtr();
+    if (ptr) {
+        console.log('📍 SPTR ID: ', ptr.getId().toString());
+        console.log('📅 Last update: ', ptr.getLastUpdate());
+    }
+}
+
+// Get a commitment by its key
+const commitmentKey = Buffer.from("...", "hex");
+const commitment = proof.getCommitment(commitmentKey);
+if (commitment) {
+    console.log('✅ Commitment root: ', Buffer.from(commitment.getRoot()).toString('hex'));
+    console.log('📅 Block height: ', commitment.getBlockHeight());
+}
+
+// Get delegated space for an SPTR
+const sptrKey = Buffer.from("...", "hex");
+const delegatedSpace = proof.getDelegation(sptrKey);
+if (delegatedSpace) {
+    console.log('✅ Delegated to space: ', delegatedSpace.toString());
+}
 ```
 
 

--- a/veritas/README.md
+++ b/veritas/README.md
@@ -116,6 +116,10 @@ if (ptrout) {
     if (ptr) {
         console.log('📍 SPTR ID: ', ptr.getId().toString());
         console.log('📅 Last update: ', ptr.getLastUpdate());
+        const data = ptr.getData();
+        if (data) {
+            console.log('📦 Data: ', Buffer.from(data).toString('utf-8'));
+        }
     }
 }
 

--- a/veritas/src/wasm.rs
+++ b/veritas/src/wasm.rs
@@ -312,6 +312,11 @@ mod wasm_api {
         pub fn get_last_update(&self) -> u32 {
             self.inner.last_update
         }
+
+        #[wasm_bindgen(js_name = "getData")]
+        pub fn get_data(&self) -> Option<Vec<u8>> {
+            self.inner.data.clone()
+        }
     }
 
     #[wasm_bindgen]
@@ -326,7 +331,7 @@ mod wasm_api {
 
         #[wasm_bindgen(js_name = "getRoot")]
         pub fn get_root(&self) -> Vec<u8> {
-            self.inner.root.to_vec()
+            self.inner.state_root.to_vec()
         }
 
         #[wasm_bindgen(js_name = "getBlockHeight")]

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -268,6 +268,10 @@ impl SpacesWallet {
         self.internal.next_unused_address(keychain_kind)
     }
 
+    pub fn reveal_next_address(&mut self, keychain_kind: KeychainKind) -> AddressInfo {
+        self.internal.reveal_next_address(keychain_kind)
+    }
+
     pub fn local_chain(&self) -> &LocalChain {
         self.internal.local_chain()
     }
@@ -601,6 +605,11 @@ impl SpacesWallet {
 
     pub fn next_unused_space_address(&mut self) -> SpaceAddress {
         let info = self.internal.next_unused_address(KeychainKind::External);
+        SpaceAddress(info.address)
+    }
+
+    pub fn reveal_next_space_address(&mut self) -> SpaceAddress {
+        let info = self.reveal_next_address(KeychainKind::External);
         SpaceAddress(info.address)
     }
 


### PR DESCRIPTION
Breaking Changes:
- Commitments now require 144-block finality window before confirmation
- Non-finalized commitments are replaced when new ones are submitted
- PTR database has been updated.

Updates:
- Support commitment rollback (if not finalized)
- Enable batch commitment submission for multiple spaces in single transaction
- Implement dual PTR transfer modes:
  * Index-preserving transfers: PTR spent at input N creates output at index N when values match (enables operator-assisted transfers)
  * Standard transfers: Maintains PTR tradability similar to spaces when values don't match. input N, output N+1
 * Trust anchors file now includes `ptrs_root` and `spaces_root`  


RPC updates:
* Support for PTR indexing now works with the same `--block-index` flag
* New RPC command `getptrblockmeta`: returns something like this:

```json
{
    "jsonrpc": "2.0",
    "result": {
        "hash": "000000001fb8d5f7d9ddb2efc13255946d870954cabcbb5d510a86c8b6ccc468",
        "height": 105986,
        "tx_meta": [
            {
                "txid": "951c4172472a2f7d30ccd3bc30167da9633b56dc937d8e890a6a02fcb578d20c",
                "spends": [
                    0
                ],
                "creates": [
                    {
                        "n": 1,
                        "id": "sptr1r5vd6za4rmmdwy2urtqs0w3rq5ja6ar5p7ak7fcmseu64fn37y0qg9e9q3",
                        "data": null,
                        "value": 1007,
                        "script_pubkey": "5120c740369227c9090a3de4fb9dbf1fc13a2f74f4b5d4c961c147fedde2c0352751"
                    }
                ],
                "commitments": {
                    "@112": {
                        "state_root": "d513cb28dd4806e4386c632bfdcf12c324c51821a6b9d1ff909e97423a1372e2",
                        "prev_root": null,
                        "history_hash": "d513cb28dd4806e4386c632bfdcf12c324c51821a6b9d1ff909e97423a1372e2",
                        "block_height": 105986
                    }
                },
                "revoked_commitments": [],
                "revoked_delegations": [],
                "new_delegations": []
            }
        ]
    },
    "id": 5
}
```


Plus more tests.