### PR TITLE
Subspaces CreatePtr Data + getAllPtrs + listAllSpaces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: aarch64-apple-darwin
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "spaces_client"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "spaces_protocol"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bincode",
  "bitcoin",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "spaces_wallet"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "bdk_wallet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "spaces_client"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "spaces_protocol"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "bincode",
  "bitcoin",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "spaces_veritas"
-version = "0.0.7"
+version = "0.0.9"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "spaces_wallet"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "bdk_wallet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,8 @@
 
 resolver = "2"
 members = [ "client", "protocol", "veritas", "testutil", "wallet"]
+
+
+[workspace.package]
+version = "0.0.9"
+edition = "2021"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 Checkout [releases](https://github.com/spacesprotocol/spaces/releases) for an immediately usable binary version of this software.
 
 
+## Work on Subspaces
+
+Spaces is live on mainnet. Subspaces is live on testnet4, and development work is happening on the [subspaces branch](https://github.com/spacesprotocol/spaces/tree/subspaces).
+
+
 ## What does it do?
 
 Spaces are sovereign Bitcoin identities. They leverage the existing infrastructure and security of Bitcoin without requiring a new blockchain or any modifications to Bitcoin itself [learn more](https://spacesprotocol.org).

--- a/SUBSPACES.md
+++ b/SUBSPACES.md
@@ -86,6 +86,12 @@ You can create an on-chain identifier that only the controller of the script pub
 $ space-cli createptr 5120d3c3196cb3ed7fa79c882ed62f8e5942e546130d5ae5983da67dbb6c9bdd2e79
 ```
 
+Optionally, you can set hex-encoded data on the created pointer using the `--data` parameter:
+
+```bash
+$ space-cli createptr 5120d3c3196cb3ed7fa79c882ed62f8e5942e546130d5ae5983da67dbb6c9bdd2e79 --data deadbeef
+```
+
 This command creates a UTXO with the same script pubkey and "mints" a space pointer (sptr) derived from it:
 
 ```

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spaces_client"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spaces_client"
-version = "0.0.8"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 
 [[bin]]

--- a/client/src/bin/space-cli.rs
+++ b/client/src/bin/space-cli.rs
@@ -18,11 +18,9 @@ use jsonrpsee::{
     core::{client::Error, ClientError},
     http_client::HttpClient,
 };
-use serde::{Deserialize, Serialize};
 use spaces_client::{
     auth::{auth_token_from_cookie, auth_token_from_creds, http_client_with_auth},
     config::{default_cookie_path, default_spaces_rpc_port, ExtendedNetwork},
-    deserialize_base64,
     format::{
         print_error_rpc_response, print_list_bidouts, print_list_spaces_response,
         print_list_transactions, print_list_unspent, print_list_wallets, print_server_info,
@@ -32,7 +30,6 @@ use spaces_client::{
         BidParams, ExecuteParams, OpenParams, RegisterParams, RpcClient, RpcWalletRequest,
         RpcWalletTxBuilder, SendCoinsParams, TransferSpacesParams,
     },
-    serialize_base64,
     wallets::{AddressKind, WalletResponse},
 };
 use spaces_protocol::bitcoin::{Amount, FeeRate, OutPoint, Txid};
@@ -369,28 +366,6 @@ struct SpaceCli {
     client: HttpClient,
 }
 
-#[derive(Serialize, Deserialize)]
-struct SignedDnsUpdate {
-    serial: u32,
-    space: String,
-    #[serde(
-        serialize_with = "serialize_base64",
-        deserialize_with = "deserialize_base64"
-    )]
-    packet: Vec<u8>,
-    signature: Signature,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    proof: Option<Base64Bytes>,
-}
-
-#[derive(Serialize, Deserialize)]
-struct Base64Bytes(
-    #[serde(
-        serialize_with = "serialize_base64",
-        deserialize_with = "deserialize_base64"
-    )]
-    Vec<u8>,
-);
 
 impl SpaceCli {
     async fn configure() -> anyhow::Result<(Self, Args)> {

--- a/client/src/bin/space-cli.rs
+++ b/client/src/bin/space-cli.rs
@@ -275,7 +275,7 @@ enum Commands {
     /// Send the specified amount of BTC to the given name or address
     #[command(
         name = "send",
-        override_usage = "space-cli send <AMOUNT> --to <SPACE-OR-ADDRESS>"
+        override_usage = "space-cli send <AMOUNT> --to <SPACE-OR-ADDRESS> [--memo <MEMO>]"
     )]
     SendCoins {
         /// Amount to send in satoshi
@@ -284,6 +284,9 @@ enum Commands {
         /// Recipient space name or address
         #[arg(long, display_order = 1)]
         to: String,
+        /// Optional memo text (max 80 characters) to include as OP_RETURN output
+        #[arg(long, display_order = 2)]
+        memo: Option<String>,
         /// Fee rate to use in sat/vB
         #[arg(long, short)]
         fee_rate: Option<u64>,
@@ -431,6 +434,9 @@ enum Commands {
         count: usize,
         #[arg(default_value = "0")]
         skip: usize,
+        /// Include memo text from OP_RETURN outputs
+        #[arg(long)]
+        with_memos: bool,
     },
     /// List won spaces including ones
     /// still in auction with a winning bid
@@ -720,6 +726,58 @@ fn parse_ptr_for_json(ptr: &spaces_ptr::FullPtrOut) -> serde_json::Value {
     ptr_json
 }
 
+fn parse_space_for_json(space: &spaces_protocol::FullSpaceOut) -> serde_json::Value {
+    use spaces_ptr::vtlv;
+    
+    let mut space_json = serde_json::to_value(space).expect("space should be serializable");
+    
+    // Check if covenant has data field (only Transfer covenant has data)
+    if let Some(obj) = space_json.as_object_mut() {
+        if let Some(covenant) = obj.get_mut("covenant") {
+            if let Some(covenant_obj) = covenant.as_object_mut() {
+                // Check if covenant type is "transfer" and has "data" field
+                if covenant_obj.get("type").and_then(|t| t.as_str()) == Some("transfer") {
+                    if let Some(data) = covenant_obj.remove("data") {
+                        // Skip if data is null
+                        if !data.is_null() {
+                            // Bytes serializes as hex string in JSON
+                            if let Some(hex_str) = data.as_str() {
+                                if let Ok(data_bytes) = hex::decode(hex_str) {
+                                    match vtlv::parse_vtlv(&data_bytes) {
+                                        Ok(parsed) => {
+                                            // Insert parsed with records structure
+                                            if let Ok(parsed_value) = serde_json::to_value(parsed) {
+                                                covenant_obj.insert("parsed".to_string(), parsed_value);
+                                            } else {
+                                                // If serialization fails, keep original data
+                                                covenant_obj.insert("data".to_string(), data);
+                                            }
+                                        }
+                                        Err(_) => {
+                                            // If parsing fails, keep the original data
+                                            covenant_obj.insert("data".to_string(), data);
+                                        }
+                                    }
+                                } else {
+                                    covenant_obj.insert("data".to_string(), data);
+                                }
+                            } else {
+                                // Not a string, keep as-is
+                                covenant_obj.insert("data".to_string(), data);
+                            }
+                        } else {
+                            // Data is null, keep it as null
+                            covenant_obj.insert("data".to_string(), data);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    space_json
+}
+
 async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), ClientError> {
     match command {
         Commands::GetRollout {
@@ -735,7 +793,15 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
         Commands::GetSpace { space } => {
             let space = normalize_space(&space);
             let response = cli.client.get_space(&space).await?;
-            println!("{}", serde_json::to_string_pretty(&response)?);
+            match response {
+                Some(space_out) => {
+                    let parsed_space = parse_space_for_json(&space_out);
+                    println!("{}", serde_json::to_string_pretty(&parsed_space)?);
+                }
+                None => {
+                    println!("null");
+                }
+            }
         }
         Commands::GetSpaceOut { outpoint } => {
             let response = cli.client.get_spaceout(outpoint).await?;
@@ -900,12 +966,24 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
         Commands::SendCoins {
             amount,
             to,
+            memo,
             fee_rate,
         } => {
+            // Validate memo length if provided
+            if let Some(ref memo_text) = memo {
+                if memo_text.len() > 80 {
+                    return Err(ClientError::Custom(format!(
+                        "memo length ({}) exceeds maximum of 80 characters",
+                        memo_text.len()
+                    )));
+                }
+            }
+
             cli.send_request(
                 Some(RpcWalletRequest::SendCoins(SendCoinsParams {
                     amount: Amount::from_sat(amount),
                     to,
+                    memo: memo.clone(),
                 })),
                 None,
                 fee_rate,
@@ -970,12 +1048,12 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
             let bidouts = cli.client.wallet_list_bidouts(&cli.wallet).await?;
             print_list_bidouts(bidouts, cli.format);
         }
-        Commands::ListTransactions { count, skip } => {
+        Commands::ListTransactions { count, skip, with_memos } => {
             let txs = cli
                 .client
-                .wallet_list_transactions(&cli.wallet, count, skip)
+                .wallet_list_transactions(&cli.wallet, count, skip, with_memos)
                 .await?;
-            print_list_transactions(txs, cli.format);
+            print_list_transactions(txs, cli.format, with_memos);
         }
         Commands::ListSpaces => {
             let tip = cli.client.get_server_info().await?;
@@ -1296,6 +1374,15 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
                 return Err(ClientError::Custom("space is not delegated - use delegate @<your-space> first.".to_string()));
             }
             let delegation = delegation.unwrap();
+
+            // Verify the PTR actually exists before trying to transfer it
+            let ptr_info = cli.client.get_ptr(delegation).await?;
+            if ptr_info.is_none() {
+                return Err(ClientError::Custom(format!(
+                    "authorize: PTR '{}' for delegation of '{}' does not exist. The delegation may have been revoked or the PTR was never created.",
+                    delegation, label
+                )));
+            }
 
             cli.send_request(
                 Some(RpcWalletRequest::Transfer(TransferSpacesParams {

--- a/client/src/bin/space-cli.rs
+++ b/client/src/bin/space-cli.rs
@@ -24,7 +24,7 @@ use spaces_client::{
     config::{default_cookie_path, default_spaces_rpc_port, ExtendedNetwork},
     deserialize_base64,
     format::{
-        print_error_rpc_response, print_list_bidouts, print_list_spaces_response,
+        print_error_rpc_response, print_list_all_spaces, print_list_bidouts, print_list_spaces_response,
         print_list_transactions, print_list_unspent, print_list_wallets, print_server_info,
         print_wallet_balance_response, print_wallet_info, print_wallet_response, Format,
     },
@@ -157,6 +157,10 @@ enum Commands {
         /// The script public key as hex string
         spk: String,
 
+        /// Hex encoded data to set on the created ptr
+        #[arg(long)]
+        data: Option<String>,
+
         #[arg(long, short)]
         fee_rate: Option<u64>,
     },
@@ -165,6 +169,13 @@ enum Commands {
     GetPtr {
         /// The sha256 hash of the spk or the spk itself prefixed with hex:
         spk: String,
+    },
+    /// Get all ptrs info (same output format as getptr)
+    #[command(name = "getallptrs")]
+    GetAllPtrs {
+        /// Only return PTRs with non-null data
+        #[arg(long)]
+        with_data: bool,
     },
     /// Transfer ownership of spaces and/or PTRs to the given name or address
     #[command(
@@ -425,6 +436,9 @@ enum Commands {
     /// still in auction with a winning bid
     #[command(name = "listspaces")]
     ListSpaces,
+    /// List all spaces in the chain state (not just wallet-related)
+    #[command(name = "listallspaces")]
+    ListAllSpaces,
     /// List unspent auction outputs i.e. outputs that can be
     /// auctioned off in the bidding process
     #[command(name = "listbidouts")]
@@ -672,6 +686,40 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn parse_ptr_for_json(ptr: &spaces_ptr::FullPtrOut) -> serde_json::Value {
+    use spaces_ptr::vtlv;
+    
+    let mut ptr_json = serde_json::to_value(ptr).expect("ptr should be serializable");
+    
+    // Since ptrout and sptr are flattened via serde(flatten), the data field
+    // appears directly in the JSON object, not nested. Look for "data" at the top level.
+    if let Some(obj) = ptr_json.as_object_mut() {
+        if let Some(data) = obj.remove("data") {
+            // Bytes serializes as hex string in JSON
+            if let Some(hex_str) = data.as_str() {
+                if let Ok(data_bytes) = hex::decode(hex_str) {
+                    match vtlv::parse_vtlv(&data_bytes) {
+                        Ok(parsed) => {
+                            obj.insert("parsed".to_string(), serde_json::to_value(parsed).expect("parsed should be serializable"));
+                        }
+                        Err(_) => {
+                            // If parsing fails, keep the original data
+                            obj.insert("data".to_string(), data);
+                        }
+                    }
+                } else {
+                    obj.insert("data".to_string(), data);
+                }
+            } else {
+                // Not a string, keep as-is
+                obj.insert("data".to_string(), data);
+            }
+        }
+    }
+    
+    ptr_json
+}
+
 async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), ClientError> {
     match command {
         Commands::GetRollout {
@@ -894,6 +942,9 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
                 .await?;
             } else {
                 // TODO: support set data for spaces
+                return Err(ClientError::Custom(format!(
+                    "setrawfallback: setting data for spaces is not yet supported. Use an SPTR (sptr1...) instead of a space name."
+                )));
                 // // Space fallback: use existing space script
                 // let space = normalize_space(&space_or_sptr);
                 // let space_script =
@@ -930,6 +981,11 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
             let tip = cli.client.get_server_info().await?;
             let spaces = cli.client.wallet_list_spaces(&cli.wallet).await?;
             print_list_spaces_response(tip.tip.height, spaces, cli.format);
+        }
+        Commands::ListAllSpaces => {
+            let tip = cli.client.get_server_info().await?;
+            let spaces = cli.client.get_all_spaces().await?;
+            print_list_all_spaces(tip.tip.height, spaces, cli.format);
         }
         Commands::Balance => {
             let balance = cli.client.wallet_get_balance(&cli.wallet).await?;
@@ -1100,15 +1156,25 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
 
             println!("{}", serde_json::to_string(&event).expect("result"));
         }
-        Commands::CreatePtr { spk, fee_rate } => {
+        Commands::CreatePtr { spk, data, fee_rate } => {
             let spk = ScriptBuf::from(hex::decode(spk)
                 .map_err(|_| ClientError::Custom("Invalid spk hex".to_string()))?);
+
+            let data = match data {
+                Some(data_hex) => {
+                    Some(hex::decode(data_hex).map_err(|e| {
+                        ClientError::Custom(format!("Could not hex decode data: {}", e))
+                    })?)
+                }
+                None => None,
+            };
 
             let sptr = Sptr::from_spk::<Sha256>(spk.clone());
             println!("Creating sptr: {}", sptr);
             cli.send_request(
                 Some(RpcWalletRequest::CreatePtr(CreatePtrParams {
                     spk: hex::encode(spk.as_bytes()),
+                    data,
                 })),
                 None,
                 fee_rate,
@@ -1126,6 +1192,17 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
                 .await
                 .map_err(|e| ClientError::Custom(e.to_string()))?;
             println!("{}", serde_json::to_string(&ptr).expect("result"));
+        }
+        Commands::GetAllPtrs { with_data } => {
+            let ptrs = cli
+                .client
+                .get_all_ptrs(with_data)
+                .await
+                .map_err(|e| ClientError::Custom(e.to_string()))?;
+            let parsed_ptrs: Vec<serde_json::Value> = ptrs.iter()
+                .map(|ptr| parse_ptr_for_json(ptr))
+                .collect();
+            println!("{}", serde_json::to_string(&parsed_ptrs).expect("result"));
         }
 
         Commands::GetPtrOut { outpoint } => {

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -279,7 +279,12 @@ impl Client {
                             // Space => Outpoint mapping will be removed
                             // since this type of revocation only happens when an
                             // expired space is being re-opened for auction.
-                            // No bids here so only remove Outpoint -> Spaceout
+                            // Remove both Space -> Outpoint and Outpoint -> Spaceout mappings
+                            if let Some(space) = update.output.spaceout.space.as_ref() {
+                                let base_hash = Sha256::hash(space.name.as_ref());
+                                let space_key = SpaceKey::from(base_hash);
+                                state.remove(space_key);
+                            }
                             let hash =
                                 OutpointKey::from_outpoint::<Sha256>(update.output.outpoint());
                             state.remove(hash);

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -15,7 +15,7 @@ use rand::{
     {thread_rng, Rng},
 };
 use serde::Deserialize;
-use spaces_protocol::bitcoin::Network;
+use spaces_protocol::{bitcoin::Network, constants::ChainAnchor};
 
 use crate::{
     auth::{auth_token_from_cookie, auth_token_from_creds},
@@ -115,6 +115,16 @@ impl ExtendedNetwork {
             "signet" => Ok(ExtendedNetwork::Signet),
             "regtest" => Ok(ExtendedNetwork::Regtest),
             _ => Err(()),
+        }
+    }
+
+    pub fn genesis(&self) -> ChainAnchor {
+        match self {
+            ExtendedNetwork::Testnet => ChainAnchor::TESTNET(),
+            ExtendedNetwork::Testnet4 => ChainAnchor::TESTNET4(),
+            ExtendedNetwork::Regtest => ChainAnchor::REGTEST(),
+            ExtendedNetwork::Mainnet => ChainAnchor::MAINNET(),
+            _ => panic!("unsupported network"),
         }
     }
 }

--- a/client/src/format.rs
+++ b/client/src/format.rs
@@ -166,10 +166,28 @@ pub fn print_list_all_spaces(
     }
 }
 
-pub fn print_list_transactions(txs: Vec<TxInfo>, format: Format) {
+pub fn print_list_transactions(txs: Vec<TxInfo>, format: Format, with_memos: bool) {
     match format {
         Format::Text => {
-            println!("{}", ascii_table(txs));
+            if with_memos {
+                // Print transactions with memos displayed separately
+                println!("{}", ascii_table(txs.iter().map(|tx| {
+                    let mut display_tx = tx.clone();
+                    // Temporarily remove memo from table display
+                    display_tx.memo = None;
+                    display_tx
+                }).collect::<Vec<_>>()));
+                
+                // Print memos separately
+                for tx in &txs {
+                    if let Some(ref memo) = tx.memo {
+                        println!("\nTransaction {}:", tx.txid);
+                        println!("  Memo: {}", memo);
+                    }
+                }
+            } else {
+                println!("{}", ascii_table(txs));
+            }
         }
         Format::Json => {
             println!("{}", serde_json::to_string_pretty(&txs).unwrap());

--- a/client/src/format.rs
+++ b/client/src/format.rs
@@ -3,7 +3,7 @@ use colored::{Color, Colorize};
 use jsonrpsee::core::Serialize;
 use serde::Deserialize;
 use spaces_protocol::{
-    bitcoin::{Amount, Network, OutPoint}, Covenant
+    bitcoin::{Amount, Network, OutPoint}, Covenant, FullSpaceOut
 };
 use spaces_wallet::{
     address::SpaceAddress,
@@ -120,6 +120,48 @@ pub fn print_list_bidouts(bidouts: Vec<DoubleUtxo>, format: Format) {
         }
         Format::Json => {
             println!("{}", serde_json::to_string_pretty(&bidouts).unwrap());
+        }
+    }
+}
+
+pub fn print_list_all_spaces(
+    _current_block: u32,
+    spaces: Vec<FullSpaceOut>,
+    format: Format,
+) {
+    match format {
+        Format::Text => {
+            #[derive(Tabled)]
+            struct AllSpaces {
+                space: String,
+                status: String,
+                value: String,
+                txid: String,
+            }
+
+            let mut table_data = Vec::new();
+            for space_out in spaces {
+                let space = space_out.spaceout.space.as_ref();
+                let space_name = space.map(|s| s.name.to_string()).unwrap_or_else(|| "unknown".to_string());
+                // All spaces returned are owned (filtered in get_all_spaces)
+                table_data.push(AllSpaces {
+                    space: space_name,
+                    status: "OWNED".to_string(),
+                    value: format!("{} sats", space_out.spaceout.value.to_sat()),
+                    txid: format!("{}", space_out.txid),
+                });
+            }
+
+            if table_data.is_empty() {
+                println!("No spaces found.");
+            } else {
+                println!("All Spaces ({} total):", table_data.len());
+                let table = Table::new(table_data);
+                println!("{}", table);
+            }
+        }
+        Format::Json => {
+            println!("{}", serde_json::to_string_pretty(&spaces).unwrap());
         }
     }
 }

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -556,8 +556,14 @@ impl WalletManager {
         let tmp = bdk::Wallet::create(external, internal)
             .network(network)
             .create_wallet_no_persist()?;
+
+        let start_block_height = match start_block_height {
+            Some(height) => height,
+            None => self.network.genesis().height,
+        };
+
         let export =
-            WalletExport::export_wallet(&tmp, &name, start_block_height.unwrap_or_default()).map_err(|e| anyhow!(e))?;
+            WalletExport::export_wallet(&tmp, &name, start_block_height).map_err(|e| anyhow!(e))?;
 
         Ok(export)
     }

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -169,6 +169,13 @@ pub enum ChainStateCommand {
         outpoint: OutPoint,
         resp: Responder<anyhow::Result<Option<PtrOut>>>,
     },
+    GetAllSpaces {
+        resp: Responder<anyhow::Result<Vec<FullSpaceOut>>>,
+    },
+    GetAllPtrs {
+        with_data: bool,
+        resp: Responder<anyhow::Result<Vec<FullPtrOut>>>,
+    },
     GetTxMeta {
         txid: Txid,
         resp: Responder<anyhow::Result<Option<TxEntry>>>,
@@ -276,6 +283,12 @@ pub trait Rpc {
 
     #[method(name = "getdelegator")]
     async fn get_delegator(&self, sptr: Sptr) -> Result<Option<SLabel>, ErrorObjectOwned>;
+
+    #[method(name = "getallspaces")]
+    async fn get_all_spaces(&self) -> Result<Vec<FullSpaceOut>, ErrorObjectOwned>;
+
+    #[method(name = "getallptrs")]
+    async fn get_all_ptrs(&self, with_data: bool) -> Result<Vec<FullPtrOut>, ErrorObjectOwned>;
 
     #[method(name = "checkpackage")]
     async fn check_package(
@@ -546,6 +559,8 @@ pub struct TransferSpacesParams {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct CreatePtrParams {
     pub spk: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -1075,6 +1090,19 @@ impl RpcServer for RpcServerImpl {
         Ok(delegator)
     }
 
+    async fn get_all_spaces(&self) -> Result<Vec<FullSpaceOut>, ErrorObjectOwned> {
+        let spaces = self.store.get_all_spaces()
+            .await
+            .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))?;
+        Ok(spaces)
+    }
+
+    async fn get_all_ptrs(&self, with_data: bool) -> Result<Vec<FullPtrOut>, ErrorObjectOwned> {
+        let ptrs = self.store.get_all_ptrs(with_data)
+            .await
+            .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))?;
+        Ok(ptrs)
+    }
 
     async fn check_package(
         &self,
@@ -1628,6 +1656,14 @@ impl AsyncChainState {
                 let result = state
                     .get_ptrout(&outpoint)
                     .context("could not fetch ptrouts");
+                let _ = resp.send(result);
+            }
+            ChainStateCommand::GetAllSpaces { resp } => {
+                let result = get_all_spaces(state);
+                let _ = resp.send(result);
+            }
+            ChainStateCommand::GetAllPtrs { with_data, resp } => {
+                let result = get_all_ptrs(state, with_data);
                 let _ = resp.send(result);
             }
             ChainStateCommand::GetBlockMeta {
@@ -2198,6 +2234,22 @@ impl AsyncChainState {
         resp_rx.await?
     }
 
+    pub async fn get_all_spaces(&self) -> anyhow::Result<Vec<FullSpaceOut>> {
+        let (resp, resp_rx) = oneshot::channel();
+        self.sender
+            .send(ChainStateCommand::GetAllSpaces { resp })
+            .await?;
+        resp_rx.await?
+    }
+
+    pub async fn get_all_ptrs(&self, with_data: bool) -> anyhow::Result<Vec<FullPtrOut>> {
+        let (resp, resp_rx) = oneshot::channel();
+        self.sender
+            .send(ChainStateCommand::GetAllPtrs { with_data, resp })
+            .await?;
+        resp_rx.await?
+    }
+
     pub async fn get_block_meta(
         &self,
         height_or_hash: HeightOrHash,
@@ -2308,6 +2360,14 @@ fn get_delegation(state: &mut Chain, space: SLabel) -> anyhow::Result<Option<Spt
         Some(delegator) if delegator == space => Ok(Some(sptr)),
         _ => Ok(None),
     }
+}
+
+fn get_all_spaces(state: &mut Chain) -> anyhow::Result<Vec<FullSpaceOut>> {
+    state.get_all_spaces()
+}
+
+fn get_all_ptrs(state: &mut Chain, with_data: bool) -> anyhow::Result<Vec<FullPtrOut>> {
+    state.get_all_ptrs(with_data)
 }
 
 fn get_commitment(state: &mut Chain, space: SLabel, root: Option<Hash>) -> anyhow::Result<Option<Commitment>> {

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -440,6 +440,7 @@ pub trait Rpc {
         wallet: &str,
         count: usize,
         skip: usize,
+        with_memos: bool,
     ) -> Result<Vec<TxInfo>, ErrorObjectOwned>;
 
     #[method(name = "walletforcespend")]
@@ -584,6 +585,7 @@ pub struct SetPtrDataParams {
 pub struct SendCoinsParams {
     pub amount: Amount,
     pub to: String,
+    pub memo: Option<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -1395,10 +1397,11 @@ impl RpcServer for RpcServerImpl {
         wallet: &str,
         count: usize,
         skip: usize,
+        with_memos: bool,
     ) -> Result<Vec<TxInfo>, ErrorObjectOwned> {
         self.wallet(&wallet)
             .await?
-            .send_list_transactions(count, skip)
+            .send_list_transactions(count, skip, with_memos)
             .await
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
     }

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -124,6 +124,13 @@ pub struct PtrBlockMetaWithHash {
     pub block_meta: PtrBlockMeta,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitmentResponse {
+    #[serde(flatten)]
+    pub commitment: Commitment,
+    pub blocks_until_finalized: u32,
+}
+
 pub enum ChainStateCommand {
     CheckPackage {
         txs: Vec<String>,
@@ -147,7 +154,7 @@ pub enum ChainStateCommand {
     GetCommitment {
         space: SLabel,
         root: Option<Hash>,
-        resp: Responder<anyhow::Result<Option<Commitment>>>,
+        resp: Responder<anyhow::Result<Option<CommitmentResponse>>>,
     },
     GetDelegation {
         space: SLabel,
@@ -276,7 +283,7 @@ pub trait Rpc {
     async fn get_ptrout(&self, outpoint: OutPoint) -> Result<Option<PtrOut>, ErrorObjectOwned>;
 
     #[method(name = "getcommitment")]
-    async fn get_commitment(&self, space: SLabel, root: Option<sha256::Hash>) -> Result<Option<Commitment>, ErrorObjectOwned>;
+    async fn get_commitment(&self, space: SLabel, root: Option<sha256::Hash>) -> Result<Option<CommitmentResponse>, ErrorObjectOwned>;
 
     #[method(name = "getdelegation")]
     async fn get_delegation(&self, space: SLabel) -> Result<Option<Sptr>, ErrorObjectOwned>;
@@ -1070,7 +1077,7 @@ impl RpcServer for RpcServerImpl {
         Ok(spaceout)
     }
 
-    async fn get_commitment(&self, space: SLabel, root: Option<sha256::Hash>) -> Result<Option<Commitment>, ErrorObjectOwned> {
+    async fn get_commitment(&self, space: SLabel, root: Option<sha256::Hash>) -> Result<Option<CommitmentResponse>, ErrorObjectOwned> {
         let c = self
             .store
             .get_commitment(space, root.map(|r| *r.as_ref()))
@@ -1649,7 +1656,19 @@ impl AsyncChainState {
             }
             ChainStateCommand::GetCommitment { space, root, resp } => {
                 let result = get_commitment(state, space, root);
-                let _ = resp.send(result);
+                let response = result.map(|opt_commitment| {
+                    opt_commitment.map(|commitment| {
+                        let current_height = state.ptrs_tip().height;
+                        let finality_height = commitment.finality_height();
+                        let blocks_until_finalized = finality_height.saturating_sub(current_height);
+                        
+                        CommitmentResponse {
+                            commitment,
+                            blocks_until_finalized,
+                        }
+                    })
+                });
+                let _ = resp.send(response);
             }
             ChainStateCommand::GetDelegation { space, resp } => {
                 let result = get_delegation(state, space);
@@ -2218,7 +2237,7 @@ impl AsyncChainState {
         resp_rx.await?
     }
 
-    pub async fn get_commitment(&self, space: SLabel, root: Option<Hash>) -> anyhow::Result<Option<Commitment>> {
+    pub async fn get_commitment(&self, space: SLabel, root: Option<Hash>) -> anyhow::Result<Option<CommitmentResponse>> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
             .send(ChainStateCommand::GetCommitment { space, root, resp })

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -74,6 +74,7 @@ pub(crate) type Responder<T> = oneshot::Sender<T>;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerInfo {
     pub network: ExtendedNetwork,
+    pub height: u32,
     pub tip: ChainAnchor,
     pub chain: ChainInfo,
     pub ready: bool,
@@ -2422,6 +2423,7 @@ async fn get_server_info(
 
     Ok(ServerInfo {
         network,
+        height: tip.height,
         tip,
         chain: ChainInfo {
             blocks: info.blocks,

--- a/client/src/spaces.rs
+++ b/client/src/spaces.rs
@@ -257,12 +257,6 @@ impl Spaced {
     }
 
     pub fn genesis(network: ExtendedNetwork) -> ChainAnchor {
-        match network {
-            ExtendedNetwork::Testnet => ChainAnchor::TESTNET(),
-            ExtendedNetwork::Testnet4 => ChainAnchor::TESTNET4(),
-            ExtendedNetwork::Regtest => ChainAnchor::REGTEST(),
-            ExtendedNetwork::Mainnet => ChainAnchor::MAINNET(),
-            _ => panic!("unsupported network"),
-        }
+        network.genesis()
     }
 }

--- a/client/src/store.rs
+++ b/client/src/store.rs
@@ -89,11 +89,11 @@ impl Store {
         Ok(Database::new(Box::new(FileBackend::new(file)?), config)?)
     }
 
-    pub fn iter(&self) -> SnapshotIterator<Sha256Hasher> {
+    pub fn iter(&self) -> SnapshotIterator<'_, Sha256Hasher> {
         return self.0.iter();
     }
 
-    pub fn write(&self) -> Result<WriteTx> {
+    pub fn write(&self) -> Result<WriteTx<'_>> {
         Ok(self.0.begin_write()?)
     }
 

--- a/client/src/store/chain.rs
+++ b/client/src/store/chain.rs
@@ -91,8 +91,16 @@ impl Chain {
         self.db.sp.state.get_space_info(space_hash)
     }
 
+    pub fn get_all_spaces(&mut self) -> anyhow::Result<Vec<FullSpaceOut>> {
+        self.db.sp.state.get_all_spaces()
+    }
+
     pub fn get_ptr_info(&mut self, key: &Sptr) -> anyhow::Result<Option<FullPtrOut>> {
         self.db.pt.state.get_ptr_info(key)
+    }
+
+    pub fn get_all_ptrs(&mut self, with_data: bool) -> anyhow::Result<Vec<FullPtrOut>> {
+        self.db.pt.state.get_all_ptrs(with_data)
     }
 
     pub fn load(_network: Network, genesis: ChainAnchor, ptrs_genesis: ChainAnchor, dir: &Path, index_spaces: bool, index_ptrs: bool) -> anyhow::Result<Self> {

--- a/client/src/store/ptrs.rs
+++ b/client/src/store/ptrs.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap},
+    collections::{BTreeMap, BTreeSet},
     fs::OpenOptions,
     io,
     io::ErrorKind,
@@ -121,6 +121,8 @@ pub trait PtrChainState {
         &mut self,
         space_hash: &Sptr,
     ) -> Result<Option<FullPtrOut>>;
+
+    fn get_all_ptrs(&mut self, with_data: bool) -> Result<Vec<FullPtrOut>>;
 }
 
 impl PtrChainState for PtrLiveSnapshot {
@@ -156,6 +158,75 @@ impl PtrChainState for PtrLiveSnapshot {
             }));
         }
         Ok(None)
+    }
+
+    fn get_all_ptrs(&mut self, with_data: bool) -> Result<Vec<FullPtrOut>> {
+        let mut ptrs = Vec::new();
+        let mut seen_keys = BTreeSet::new();
+        
+        // First, collect staged changes (memory) - collect Sptr keys first, then process
+        let mut staged_sptrs = Vec::new();
+        {
+            let rlock = self.staged.read().expect("acquire lock");
+            for (key, value) in rlock.memory.iter() {
+                // Skip deleted entries
+                if value.is_none() {
+                    continue;
+                }
+                
+                // Try to decode key as Sptr (32 bytes) - Hash is already [u8; 32]
+                // Use unsafe transmute since Hash and Sptr are both [u8; 32]
+                let sptr = unsafe { std::mem::transmute::<Hash, Sptr>(*key) };
+                
+                // Check if value decodes as EncodableOutpoint (indicates it's a PTR entry)
+                if let Some(value) = value {
+                    let decode_result: Result<(EncodableOutpoint, usize), _> = bincode::decode_from_slice(&value, config::standard());
+                    if decode_result.is_ok() {
+                        seen_keys.insert(*key);
+                        staged_sptrs.push(sptr);
+                    }
+                }
+            }
+        }
+        
+        // Now process staged SPTRs (lock is dropped)
+        for sptr in staged_sptrs {
+            if let Ok(Some(ptr_out)) = self.get_ptr_info(&sptr) {
+                // Filter by with_data flag if set
+                if !with_data || (ptr_out.ptrout.sptr.is_some() && ptr_out.ptrout.sptr.as_ref().unwrap().data.is_some()) {
+                    ptrs.push(ptr_out);
+                }
+            }
+        }
+        
+        // Then iterate through snapshot
+        let snapshot = self.inner()?;
+        for item in snapshot.iter() {
+            let (key, value) = item?;
+            
+            // Skip if already processed from staged changes
+            if seen_keys.contains(&key) {
+                continue;
+            }
+            
+            // Try to decode key as Sptr (32 bytes) - Hash is already [u8; 32]
+            // Use unsafe transmute since Hash and Sptr are both [u8; 32]
+            let sptr = unsafe { std::mem::transmute::<Hash, Sptr>(key) };
+            
+            // Check if value decodes as EncodableOutpoint (indicates it's a PTR entry)
+            let decode_result: Result<(EncodableOutpoint, usize), _> = bincode::decode_from_slice(&value, config::standard());
+            if decode_result.is_ok() {
+                // Try to get ptr info - if successful, it's a valid PTR
+                if let Ok(Some(ptr_out)) = self.get_ptr_info(&sptr) {
+                    // Filter by with_data flag if set
+                    if !with_data || (ptr_out.ptrout.sptr.is_some() && ptr_out.ptrout.sptr.as_ref().unwrap().data.is_some()) {
+                        ptrs.push(ptr_out);
+                    }
+                }
+            }
+        }
+        
+        Ok(ptrs)
     }
 }
 

--- a/client/src/store/spaces.rs
+++ b/client/src/store/spaces.rs
@@ -174,6 +174,8 @@ pub trait SpacesState {
         &mut self,
         space_hash: &spaces_protocol::hasher::SpaceKey,
     ) -> anyhow::Result<Option<FullSpaceOut>>;
+
+    fn get_all_spaces(&mut self) -> anyhow::Result<Vec<FullSpaceOut>>;
 }
 
 impl SpacesState for SpLiveSnapshot {
@@ -204,6 +206,79 @@ impl SpacesState for SpLiveSnapshot {
             }));
         }
         Ok(None)
+    }
+
+    fn get_all_spaces(&mut self) -> anyhow::Result<Vec<FullSpaceOut>> {
+        let mut spaces = Vec::new();
+        let mut seen_keys = BTreeSet::new();
+        
+        // First, collect staged changes (memory) - collect outpoints first, then process
+        let mut staged_outpoints = Vec::new();
+        {
+            let rlock = self.staged.read().expect("acquire lock");
+            for (key, value) in rlock.memory.iter() {
+                if SpaceKey::is_valid(key) {
+                    // Skip deleted entries
+                    if value.is_none() {
+                        continue;
+                    }
+                    
+                    if let Some(value) = value {
+                        let decode_result: Result<(EncodableOutpoint, usize), _> = bincode::decode_from_slice(&value, config::standard());
+                        if let Ok((outpoint_enc, _)) = decode_result {
+                            seen_keys.insert(*key);
+                            let outpoint: OutPoint = outpoint_enc.into();
+                            staged_outpoints.push(outpoint);
+                        }
+                    }
+                }
+            }
+        }
+        
+        // Now process staged outpoints (lock is dropped)
+        for outpoint in staged_outpoints {
+            if let Ok(Some(spaceout)) = self.get_spaceout(&outpoint) {
+                // Only include owned spaces
+                if spaceout.space.as_ref().map(|s| s.is_owned()).unwrap_or(false) {
+                    spaces.push(FullSpaceOut {
+                        txid: outpoint.txid,
+                        spaceout,
+                    });
+                }
+            }
+        }
+        
+        // Then iterate through snapshot
+        let snapshot = self.inner()?;
+        for item in snapshot.iter() {
+            let (key, value) = item?;
+            
+            // Only process SpaceKey entries (not BidKey or OutpointKey)
+            if SpaceKey::is_valid(&key) {
+                // Skip if already processed from staged changes
+                if seen_keys.contains(&key) {
+                    continue;
+                }
+                
+                // Decode the value as EncodableOutpoint
+                let decode_result: Result<(EncodableOutpoint, usize), _> = bincode::decode_from_slice(&value, config::standard());
+                if let Ok((outpoint_enc, _)) = decode_result {
+                    let outpoint: OutPoint = outpoint_enc.into();
+                    // Get the spaceout for this outpoint
+                    if let Ok(Some(spaceout)) = self.get_spaceout(&outpoint) {
+                        // Only include owned spaces
+                        if spaceout.space.as_ref().map(|s| s.is_owned()).unwrap_or(false) {
+                            spaces.push(FullSpaceOut {
+                                txid: outpoint.txid,
+                                spaceout,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        
+        Ok(spaces)
     }
 }
 

--- a/client/src/wallets.rs
+++ b/client/src/wallets.rs
@@ -820,12 +820,6 @@ impl RpcWallet {
         let mut pending = vec![];
         let mut outbid = vec![];
         for (txid, event) in recent_events {
-            let tx = wallet.get_tx(txid);
-            if tx.as_ref().is_some_and(|tx| !tx.chain_position.is_confirmed()) {
-                pending.push(SLabel::from_str(event.space.as_ref().unwrap()).expect("valid space name"));
-                continue;
-            }
-
             if unspent.iter().any(|out| {
                 out.space
                     .as_ref()
@@ -833,6 +827,13 @@ impl RpcWallet {
             }) {
                 continue;
             }
+
+            let tx = wallet.get_tx(txid);
+            if tx.as_ref().is_some_and(|tx| !tx.chain_position.is_confirmed()) {
+                pending.push(SLabel::from_str(event.space.as_ref().unwrap()).expect("valid space name"));
+                continue;
+            }
+
             let name = SLabel::from_str(event.space.as_ref().unwrap()).expect("valid space name");
             let spacehash = SpaceKey::from(Sha256::hash(name.as_ref()));
             let space = state.get_space_info(&spacehash)?;

--- a/client/src/wallets.rs
+++ b/client/src/wallets.rs
@@ -1295,7 +1295,11 @@ impl RpcWallet {
 
                     builder = builder.add_ptr(PtrRequest {
                         spk,
-                    })
+                    });
+                    
+                    if let Some(data) = params.data {
+                        builder = builder.add_data(data);
+                    }
                 }
                 RpcWalletRequest::Commit(params) => {
                     let reqs = commit_params_to_req(chain, wallet, params)?;

--- a/client/src/wallets.rs
+++ b/client/src/wallets.rs
@@ -84,7 +84,7 @@ impl FromStr for ResolvableTarget {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.trim();
         if let Some(rest) = s.strip_prefix('@') {
-            return SLabel::from_str(rest)
+            return SLabel::from_str_unprefixed(rest)
                 .map(ResolvableTarget::Space)
                 .map_err(ResolvableTargetParseError::SpaceLabelParseError);
         }
@@ -190,6 +190,8 @@ pub struct TxInfo {
     pub fee: Option<Amount>,
     #[tabled(rename = "DETAILS", display_with = "display_events")]
     pub events: Vec<TxEvent>,
+    #[tabled(skip)]
+    pub memo: Option<String>,
 }
 
 fn display_block_height(block_height: &Option<u32>) -> String {
@@ -249,6 +251,7 @@ pub enum WalletCommand {
     ListTransactions {
         count: usize,
         skip: usize,
+        with_memos: bool,
         resp: crate::rpc::Responder<anyhow::Result<Vec<TxInfo>>>,
     },
     ListSpaces {
@@ -547,8 +550,8 @@ impl RpcWallet {
             WalletCommand::ListUnspent { resp } => {
                 _ = resp.send(wallet.list_unspent_with_details(chain));
             }
-            WalletCommand::ListTransactions { count, skip, resp } => {
-                let transactions = Self::list_transactions(wallet, count, skip);
+            WalletCommand::ListTransactions { count, skip, with_memos, resp } => {
+                let transactions = Self::list_transactions(wallet, count, skip, with_memos);
                 _ = resp.send(transactions);
             }
             WalletCommand::ListSpaces { resp } => {
@@ -958,7 +961,10 @@ impl RpcWallet {
         wallet: &mut SpacesWallet,
         count: usize,
         skip: usize,
+        with_memos: bool,
     ) -> anyhow::Result<Vec<TxInfo>> {
+        use spaces_protocol::script::find_op_set_data;
+        
         let mut transactions: Vec<_> = wallet.transactions().collect();
         transactions.sort();
 
@@ -976,6 +982,27 @@ impl RpcWallet {
                 let txid = ctx.tx_node.txid.clone();
                 let (sent, received) = wallet.sent_and_received(&tx);
                 let fee = wallet.calculate_fee(&tx).ok();
+                
+                // Extract memo from OP_RETURN if requested
+                let memo = if with_memos {
+                    find_op_set_data(&tx.output)
+                        .and_then(|data_bytes| {
+                            let data_slice = data_bytes.as_slice();
+                            // Try to decode as hex string first (since we encode memos as hex)
+                            if let Ok(hex_str) = String::from_utf8(data_slice.to_vec()) {
+                                if let Ok(decoded) = hex::decode(&hex_str) {
+                                    if let Ok(original_text) = String::from_utf8(decoded) {
+                                        return Some(original_text);
+                                    }
+                                }
+                            }
+                            // Fallback: try to decode as UTF-8 directly
+                            String::from_utf8(data_slice.to_vec()).ok()
+                        })
+                } else {
+                    None
+                };
+                
                 TxInfo {
                     block_height,
                     txid,
@@ -983,6 +1010,7 @@ impl RpcWallet {
                     received,
                     fee,
                     events: vec![],
+                    memo,
                 }
             })
             .collect();
@@ -1107,6 +1135,14 @@ impl RpcWallet {
                         amount: params.amount,
                         recipient: recipient.clone(),
                     });
+                    
+                    // Add memo as OP_RETURN output if provided
+                    if let Some(memo_text) = &params.memo {
+                        // Convert memo text to hex-encoded bytes (hex string representation)
+                        let hex_string = hex::encode(memo_text.as_bytes());
+                        let memo_bytes = hex_string.as_bytes().to_vec();
+                        builder = builder.add_data(memo_bytes);
+                    }
                 }
                 RpcWalletRequest::Transfer(params) => {
                     let recipient = if let Some(to) = params.to {
@@ -1642,10 +1678,11 @@ impl RpcWallet {
         &self,
         count: usize,
         skip: usize,
+        with_memos: bool,
     ) -> anyhow::Result<Vec<TxInfo>> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
-            .send(WalletCommand::ListTransactions { count, skip, resp })
+            .send(WalletCommand::ListTransactions { count, skip, with_memos, resp })
             .await?;
         resp_rx.await?
     }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spaces_protocol"
-version = "0.0.8"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 bitcoin = { version = "0.32.2", features = ["base64", "serde"], default-features = false }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spaces_protocol"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 
 [dependencies]

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -350,7 +350,7 @@ impl FullSpaceOut {
 
     pub fn refund_signing_info(
         &self,
-    ) -> Option<(Transaction, Prevouts<TxOut>, schnorr::Signature)> {
+    ) -> Option<(Transaction, Prevouts<'_, TxOut>, schnorr::Signature)> {
         if self.spaceout.space.is_none() {
             return None;
         }

--- a/protocol/src/slabel.rs
+++ b/protocol/src/slabel.rs
@@ -248,7 +248,7 @@ impl Display for SLabelRef<'_> {
 }
 
 impl SLabel {
-    pub fn as_name_ref(&self) -> SLabelRef {
+    pub fn as_name_ref(&self) -> SLabelRef<'_> {
         SLabelRef(&self.0)
     }
 

--- a/ptr/src/lib.rs
+++ b/ptr/src/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "std")]
 pub mod sptr;
 pub mod constants;
+#[cfg(feature = "serde")]
+pub mod vtlv;
 
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};

--- a/ptr/src/lib.rs
+++ b/ptr/src/lib.rs
@@ -17,6 +17,8 @@ use bitcoin::script::{Instruction, PushBytesBuf};
 use spaces_protocol::hasher::{KeyHasher, KeyHash, Hash};
 use spaces_protocol::slabel::SLabel;
 use spaces_protocol::{Bytes, SpaceOut};
+#[cfg(feature = "std")]
+use log::info;
 use crate::constants::COMMITMENT_FINALITY_INTERVAL;
 use crate::sptr::{Sptr};
 
@@ -192,6 +194,11 @@ impl Commitment {
     pub fn is_finalized(&self, height: u32) -> bool {
         let finality_height = self.block_height + COMMITMENT_FINALITY_INTERVAL;
         height > finality_height
+    }
+
+    /// Returns the block height at which this commitment will be finalized
+    pub fn finality_height(&self) -> u32 {
+        self.block_height + COMMITMENT_FINALITY_INTERVAL
     }
 }
 
@@ -505,6 +512,19 @@ impl Validator {
                                     }
                                 }
                             };
+                            // Log finality height for administrator visibility
+                            #[cfg(feature = "std")]
+                            {
+                                let finality_height = commitment.finality_height();
+                                let blocks_remaining = finality_height.saturating_sub(height);
+                                info!(
+                                    "New commitment created for space '{}' at block height {}: finality_height={}, blocks_until_finalized={}",
+                                    delegate.space.clone(),
+                                    height,
+                                    finality_height,
+                                    blocks_remaining
+                                );
+                            }
                             // Revoke pending commitment
                             if let Some(pending) = delegate.pending_tip {
                                 changeset.revoked_commitments.push(

--- a/ptr/src/vtlv.rs
+++ b/ptr/src/vtlv.rs
@@ -1,0 +1,214 @@
+//! VTLV (Version-Type-Length-Value) parser implementation
+//! Based on SCHEMA.md from spaces-hex-tool
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct VtlvRecord {
+    pub version: u8,
+    pub r#type: u8,
+    pub length: u16,
+    pub value: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct ParsedData {
+    pub version: u8,
+    pub records: Vec<ParsedRecord>,
+}
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct ParsedRecord {
+    pub r#type: u8,
+    pub name: String,
+    pub value: ParsedValue,
+}
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ParsedValue {
+    String(String),
+    Hex(String),
+    Bytes(Vec<u8>),
+}
+
+/// Parse VTLV data according to SCHEMA.md
+pub fn parse_vtlv(data: &[u8]) -> Result<ParsedData, String> {
+    if data.is_empty() {
+        return Err("Empty data".to_string());
+    }
+
+    let mut offset = 0;
+    let version = data[offset];
+    offset += 1;
+
+    let mut records = Vec::new();
+
+    if version == 0x00 {
+        // Version 0x00: Length (2 bytes) + Value (N bytes)
+        if data.len() < 3 {
+            return Err("Insufficient data for version 0x00".to_string());
+        }
+        let length = u16::from_be_bytes([data[offset], data[offset + 1]]);
+        offset += 2;
+        if offset + length as usize > data.len() {
+            return Err("Length exceeds data size".to_string());
+        }
+        let value = data[offset..offset + length as usize].to_vec();
+        records.push(ParsedRecord {
+            r#type: 0x00,
+            name: "Data".to_string(),
+            value: ParsedValue::Hex(hex::encode(&value)),
+        });
+    } else {
+        // Version > 0x01: Repeated Type (1 byte) + Length (1 byte) + Value (N bytes)
+        while offset < data.len() {
+            if offset + 2 > data.len() {
+                break; // Need at least Type + Length
+            }
+
+            let r#type = data[offset];
+            offset += 1;
+            let length = data[offset] as usize;
+            offset += 1;
+
+            if offset + length > data.len() {
+                break; // Not enough data
+            }
+
+            let value_bytes = &data[offset..offset + length];
+            offset += length;
+
+            let name = type_to_name(r#type);
+            let value = parse_value(r#type, value_bytes);
+
+            records.push(ParsedRecord {
+                r#type,
+                name,
+                value,
+            });
+        }
+    }
+
+    Ok(ParsedData { version, records })
+}
+
+fn type_to_name(r#type: u8) -> String {
+    match r#type {
+        0x00 => "Handle".to_string(),
+        0x01 => "Owner URI".to_string(),
+        0x02 => "Nostr Pubkey".to_string(),
+        0x03 => "Nostr Relay".to_string(),
+        0x04 => "Pubky.app Pubkey".to_string(),
+        0x05 => "Decentralized ID".to_string(),
+        0x06 => "DNS A Record".to_string(),
+        0x07 => "DNS CNAME".to_string(),
+        0x08 => "DNS SMTP".to_string(),
+        0x09 => "DNS TXT".to_string(),
+        0x0A => "Bitcoin Address".to_string(),
+        0x0B => "Ethereum Address".to_string(),
+        _ => format!("Reserved (0x{:02X})", r#type),
+    }
+}
+
+fn parse_value(r#type: u8, value_bytes: &[u8]) -> ParsedValue {
+    match r#type {
+        0x00 => {
+            // Handle: Space handle identifier - try to parse as UTF-8
+            String::from_utf8(value_bytes.to_vec())
+                .map(ParsedValue::String)
+                .unwrap_or_else(|_| ParsedValue::Hex(hex::encode(value_bytes)))
+        }
+        0x01 => {
+            // Owner URI: RPC Interface or Info Website - UTF-8 string
+            String::from_utf8(value_bytes.to_vec())
+                .map(ParsedValue::String)
+                .unwrap_or_else(|_| ParsedValue::Hex(hex::encode(value_bytes)))
+        }
+        0x02 => {
+            // Nostr Pubkey: 64 hex digits (32 bytes)
+            ParsedValue::Hex(hex::encode(value_bytes))
+        }
+        0x03 => {
+            // Nostr Relay: WebSocket relay - UTF-8 string
+            String::from_utf8(value_bytes.to_vec())
+                .map(ParsedValue::String)
+                .unwrap_or_else(|_| ParsedValue::Hex(hex::encode(value_bytes)))
+        }
+        0x04 => {
+            // Pubky.app Pubkey: UTF-8 string
+            String::from_utf8(value_bytes.to_vec())
+                .map(ParsedValue::String)
+                .unwrap_or_else(|_| ParsedValue::Hex(hex::encode(value_bytes)))
+        }
+        0x05 => {
+            // Decentralized ID: DID identifier (68 bytes hex) - UTF-8 string
+            String::from_utf8(value_bytes.to_vec())
+                .map(ParsedValue::String)
+                .unwrap_or_else(|_| ParsedValue::Hex(hex::encode(value_bytes)))
+        }
+        0x06 => {
+            // DNS A Record: IPv4/IPv6 address as hex
+            ParsedValue::Hex(hex::encode(value_bytes))
+        }
+        0x07 => {
+            // DNS CNAME: Canonical name - UTF-8 string
+            String::from_utf8(value_bytes.to_vec())
+                .map(ParsedValue::String)
+                .unwrap_or_else(|_| ParsedValue::Hex(hex::encode(value_bytes)))
+        }
+        0x08 => {
+            // DNS SMTP: SMTP server address - UTF-8 string
+            String::from_utf8(value_bytes.to_vec())
+                .map(ParsedValue::String)
+                .unwrap_or_else(|_| ParsedValue::Hex(hex::encode(value_bytes)))
+        }
+        0x09 => {
+            // DNS TXT: Arbitrary ASCII text - UTF-8 string
+            String::from_utf8(value_bytes.to_vec())
+                .map(ParsedValue::String)
+                .unwrap_or_else(|_| ParsedValue::Hex(hex::encode(value_bytes)))
+        }
+        0x0A => {
+            // Bitcoin Address: UTF-8 string
+            String::from_utf8(value_bytes.to_vec())
+                .map(ParsedValue::String)
+                .unwrap_or_else(|_| ParsedValue::Hex(hex::encode(value_bytes)))
+        }
+        0x0B => {
+            // Ethereum Address: UTF-8 string
+            String::from_utf8(value_bytes.to_vec())
+                .map(ParsedValue::String)
+                .unwrap_or_else(|_| ParsedValue::Hex(hex::encode(value_bytes)))
+        }
+        _ => {
+            // Unknown type: return as hex
+            ParsedValue::Hex(hex::encode(value_bytes))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_version_00() {
+        let data = vec![0x00, 0x00, 0x05, 0x48, 0x65, 0x6C, 0x6C, 0x6F]; // Version 0x00, Length 5, "Hello"
+        let result = parse_vtlv(&data).unwrap();
+        assert_eq!(result.version, 0x00);
+        assert_eq!(result.records.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_version_01() {
+        // Version 0x01, Type 0x02 (Nostr Pubkey), Length 0x20, 32 bytes
+        let mut data = vec![0x01, 0x02, 0x20];
+        data.extend_from_slice(&[0u8; 32]);
+        let result = parse_vtlv(&data).unwrap();
+        assert_eq!(result.version, 0x01);
+        assert_eq!(result.records.len(), 1);
+        assert_eq!(result.records[0].r#type, 0x02);
+    }
+}
+

--- a/veritas/Cargo.toml
+++ b/veritas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spaces_veritas"
-version = "0.0.7"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/veritas/src/lib.rs
+++ b/veritas/src/lib.rs
@@ -103,7 +103,7 @@ impl Veritas {
 }
 
 impl Proof {
-    pub fn iter(&self) -> ProofIter {
+    pub fn iter(&self) -> ProofIter<'_> {
         ProofIter {
             inner: self.inner.iter(),
         }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spaces_wallet"
-version = "0.0.8"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 spaces_protocol = { path = "../protocol", features = ["std"], version = "*" }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spaces_wallet"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 
 [dependencies]

--- a/wallet/src/builder.rs
+++ b/wallet/src/builder.rs
@@ -405,7 +405,6 @@ impl Builder {
             if !coin_transfers.is_empty() {
                 for coin in coin_transfers {
                     builder.add_send(coin)?;
-                    vout += 1;
                 }
             }
 
@@ -720,7 +719,7 @@ impl Builder {
         wallet: &mut SpacesWallet,
         unspendables: Vec<OutPoint>,
         confirmed_only: bool,
-    ) -> anyhow::Result<BuilderIterator> {
+    ) -> anyhow::Result<BuilderIterator<'_>> {
         let fee_rate = self
             .fee_rate
             .as_ref()

--- a/wallet/src/builder.rs
+++ b/wallet/src/builder.rs
@@ -939,6 +939,7 @@ impl Builder {
         }
 
         let has_transfers = !params.transfers.is_empty();
+        let has_binds = !params.binds.is_empty();
 
         // Handle transfers:
         for transfer in params.transfers {
@@ -962,9 +963,9 @@ impl Builder {
             );
         }
 
-        // Add data OP_RETURN if present (only makes sense with transfers)
+        // Add data OP_RETURN if present (works with transfers or binds)
         if let Some(data) = params.data {
-            if has_transfers {
+            if has_transfers || has_binds {
                 let script = create_data_script(&data);
                 builder.add_recipient(script, Amount::from_sat(0));
             }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -256,7 +256,7 @@ impl SpacesWallet {
         })
     }
 
-    pub fn get_tx(&mut self, txid: Txid) -> Option<WalletTx> {
+    pub fn get_tx(&mut self, txid: Txid) -> Option<WalletTx<'_>> {
         self.internal.get_tx(txid)
     }
 
@@ -281,7 +281,7 @@ impl SpacesWallet {
         })
     }
 
-    pub fn transactions(&self) -> impl Iterator<Item=WalletTx> + '_ {
+    pub fn transactions(&self) -> impl Iterator<Item=WalletTx<'_>> + '_ {
         self.internal
             .transactions()
             .filter(|tx| !is_revert_tx(tx) && self.internal.spk_index().is_tx_relevant(&tx.tx_node))
@@ -299,7 +299,7 @@ impl SpacesWallet {
         &mut self,
         unspendables: Vec<OutPoint>,
         confirmed_only: bool,
-    ) -> anyhow::Result<TxBuilder<SpacesAwareCoinSelection>> {
+    ) -> anyhow::Result<TxBuilder<'_, SpacesAwareCoinSelection>> {
         self.create_builder(unspendables, None, confirmed_only)
     }
 
@@ -530,7 +530,7 @@ impl SpacesWallet {
     ///
     /// This is used to monitor bid txs in the mempool
     /// to check if they have been replaced.
-    pub fn unconfirmed_bids(&mut self) -> anyhow::Result<Vec<(WalletTx, OutPoint)>> {
+    pub fn unconfirmed_bids(&mut self) -> anyhow::Result<Vec<(WalletTx<'_>, OutPoint)>> {
         let txids: Vec<_> = {
             let unconfirmed: Vec<_> = self
                 .transactions()


### PR DESCRIPTION
Adds an optional --data parameter to createptr to allow initial setting of the "data" field with arbitrary hex data.

The hex data can contain multiple items, parsed by [schema](https://github.com/horologger/spaces-hex-tool/blob/main/SCHEMA.md) as implemented in the spaces-hex-tool.

Also adds a getallptrs command to return all ptrs on the chain and decode the available data by schema.

Also adds a listallspaces command to return all spaces on the chain in an owned state with optional --with-data param to limited those returned having non-null "data".