### PR TITLE
Index cleanups

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -315,6 +315,14 @@ impl Client {
         for revoked in changeset.revoked_commitments {
             let commitment_key = CommitmentKey::new::<Sha256>(&revoked.space, revoked.commitment.state_root);
             state.remove_commitment(commitment_key);
+
+            let registry_key = RegistryKey::from_slabel::<Sha256>(&revoked.space);
+            if let Some(prev) = revoked.commitment.prev_root {
+                // Points space -> prev commitments tip
+                state.insert_registry(registry_key, prev);
+            } else {
+                state.remove_registry(registry_key);
+            }
         }
 
         // Create new delegations

--- a/client/src/store/chain.rs
+++ b/client/src/store/chain.rs
@@ -300,6 +300,10 @@ impl Chain {
         self.db.pt.state.insert_registry(key, state_root)
     }
 
+    pub(crate) fn remove_registry(&self, key: RegistryKey) {
+        self.db.pt.state.remove_registry(key)
+    }
+
     pub fn remove_ptr_utxo(&mut self, outpoint: OutPoint) {
         let key = OutpointKey::from_outpoint::<Sha256>(outpoint);
         self.db.pt.state.remove(key)

--- a/client/src/store/chain.rs
+++ b/client/src/store/chain.rs
@@ -96,7 +96,7 @@ impl Chain {
     }
 
     pub fn load(_network: Network, genesis: ChainAnchor, ptrs_genesis: ChainAnchor, dir: &Path, index_spaces: bool, index_ptrs: bool) -> anyhow::Result<Self> {
-        let proto_db_path = dir.join("spaces.sdb");
+        let proto_db_path = dir.join("root.sdb");
         let ptrs_db_path = dir.join("refs.sdb");
         let initial_sp_sync = !proto_db_path.exists();
         let initial_pt_sync = !ptrs_db_path.exists();

--- a/client/src/store/ptrs.rs
+++ b/client/src/store/ptrs.rs
@@ -113,6 +113,7 @@ pub trait PtrChainState {
     fn insert_ptrout(&self, key: PtrOutpointKey, ptrout: PtrOut);
     fn insert_commitment(&self, key: CommitmentKey, commitment: Commitment);
     fn insert_registry(&self, key: RegistryKey, state_root: Hash);
+    fn remove_registry(&self, key: RegistryKey);
     fn insert_registry_delegation(&self, key: RegistrySptrKey, space: SLabel);
     fn insert_ptr(&self, key: Sptr, outpoint: EncodableOutpoint);
 
@@ -134,6 +135,10 @@ impl PtrChainState for PtrLiveSnapshot {
 
     fn insert_registry(&self, key: RegistryKey, state_root: Hash) {
         self.insert(key, state_root)
+    }
+
+    fn remove_registry(&self, key: RegistryKey) {
+        self.remove(key)
     }
 
     fn insert_registry_delegation(&self, key: RegistrySptrKey, space: SLabel) {

--- a/protocol/src/validate.rs
+++ b/protocol/src/validate.rs
@@ -284,13 +284,17 @@ impl Validator {
                 }
 
                 // Revoke the previously expired space
-                changeset.updates.push(UpdateOut {
-                    kind: UpdateKind::Revoke(RevokeReason::Expired),
-                    output: FullSpaceOut {
-                        txid: prev.txid,
-                        spaceout: prev.spaceout.clone(),
-                    },
-                });
+                if !changeset.updates.iter()
+                    .any(|update| update.output.outpoint() == prev.outpoint() &&
+                        matches!(update.kind, UpdateKind::Revoke(_))) {
+                    changeset.updates.push(UpdateOut {
+                        kind: UpdateKind::Revoke(RevokeReason::Expired),
+                        output: FullSpaceOut {
+                            txid: prev.txid,
+                            spaceout: prev.spaceout.clone(),
+                        },
+                    });
+                }
                 prev.spaceout.space.unwrap().name
             }
             OpenContext::NewSpace(name) => name,


### PR DESCRIPTION
This PR ensures:

1. `get_commitment` returns the tip even after rollback if root wasn't specified explicitly 
2. Fixes crash for expired spaces. This fix ensures the revoke event is emitted correctly and prevents showing a duplicate revoke event in some cases. The fix is different from PR #122 in the main branch in that it keeps the relevant assertions, and ensures the index is always consistent so there's no need for graceful checks in get_space. 