### PR TITLE
Introduce numeric aliases to sptrs

### DIFF
--- a/client/src/bin/space-cli.rs
+++ b/client/src/bin/space-cli.rs
@@ -28,7 +28,7 @@ use spaces_client::{
     },
     rpc::{
         BidParams, OpenParams, RegisterParams, RpcClient, RpcWalletRequest,
-        RpcWalletTxBuilder, SendCoinsParams, SpaceOrPtr, TransferSpacesParams,
+        RpcWalletTxBuilder, SendCoinsParams, Subject, TransferSpacesParams,
     },
     wallets::{AddressKind, WalletResponse},
 };
@@ -36,6 +36,7 @@ use spaces_client::rpc::{CommitParams, CreatePtrParams, DelegateParams, SetPtrDa
 use spaces_client::store::Sha256;
 use spaces_protocol::bitcoin::{Amount, FeeRate, OutPoint, Txid};
 use spaces_protocol::slabel::SLabel;
+use spaces_ptr::snumeric::SNumeric;
 use spaces_ptr::sptr::Sptr;
 use spaces_wallet::{bitcoin::secp256k1::schnorr::Signature, export::WalletExport, nostr::{NostrEvent, NostrTag}, Listing};
 use spaces_wallet::bitcoin::hashes::sha256;
@@ -237,7 +238,8 @@ enum Commands {
     /// Get the current space a sptr is responsible for
     #[command(name = "getdelegator")]
     GetDelegator {
-        sptr: Sptr,
+        /// The sptr or numeric identifier (e.g., sptr1... or #800000-3)
+        sptr: String,
     },
     /// Get the current sptr responsible for a space
     #[command(name = "getdelegation")]
@@ -402,8 +404,8 @@ enum Commands {
     /// Associate on-chain record data with a space/sptr as a fallback to P2P options like Fabric.
     #[command(name = "setrawfallback")]
     SetRawFallback {
-        /// Space name or SPTR identifier
-        space_or_sptr: String,
+        /// Space name, SPTR, or numeric identifier
+        subject: String,
         /// Hex encoded data
         data: String,
         /// Fee rate to use in sat/vB
@@ -500,11 +502,11 @@ impl SpaceCli {
         anchor: bool,
         most_recent: bool,
     ) -> Result<NostrEvent, ClientError> {
-        let space_or_ptr = parse_space_or_ptr(&space)
-            .map_err(|e| ClientError::Custom(format!("Invalid space or sptr: {}", e)))?;
+        let subject = parse_subject(&space)
+            .map_err(|e| ClientError::Custom(format!("Invalid subject: {}", e)))?;
         let mut result = self
             .client
-            .wallet_sign_event(&self.wallet, space_or_ptr, event)
+            .wallet_sign_event(&self.wallet, subject, event)
             .await?;
 
         if anchor {
@@ -596,17 +598,19 @@ fn normalize_space(space: &str) -> String {
     }
 }
 
-/// Parse a string as either a space name or an sptr
-fn parse_space_or_ptr(s: &str) -> anyhow::Result<SpaceOrPtr> {
-    // Try to parse as SPTR first (starts with "sptr1")
+/// Parse a string as a space name, sptr, or numeric identifier
+fn parse_subject(s: &str) -> anyhow::Result<Subject> {
     if s.starts_with("sptr1") {
         Sptr::from_str(s)
-            .map(SpaceOrPtr::Ptr)
+            .map(Subject::Ptr)
             .map_err(|e| anyhow!("Invalid sptr: {}", e))
+    } else if s.starts_with('#') {
+        SNumeric::from_str(s)
+            .map(Subject::Numeric)
+            .map_err(|e| anyhow!("Invalid numeric: {}", e))
     } else {
-        // Otherwise parse as space name
         SLabel::from_str(s)
-            .map(SpaceOrPtr::Space)
+            .map(Subject::Space)
             .map_err(|e| anyhow!("Invalid space name: {}", e))
     }
 }
@@ -778,10 +782,9 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
             .await?
         }
         Commands::Renew { spaces, fee_rate } => {
-            use spaces_client::rpc::SpaceOrPtr;
             let spaces: Vec<_> = spaces.into_iter().map(|s| {
                 let normalized = normalize_space(&s);
-                SpaceOrPtr::Space(SLabel::from_str(&normalized).expect("valid space"))
+                Subject::Space(SLabel::from_str(&normalized).expect("valid space"))
             }).collect();
             cli.send_request(
                 Some(RpcWalletRequest::Transfer(TransferSpacesParams {
@@ -801,17 +804,17 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
             data,
             fee_rate,
         } => {
-            use spaces_client::rpc::SpaceOrPtr;
-            // Parse spaces and PTRs into SpaceOrPtr
+            // Parse spaces, PTRs, and numerics into Subject
             let spaces: Result<Vec<_>, _> = spaces.into_iter().map(|s| {
                 if s.starts_with("sptr1") {
-                    // Parse as SPTR
-                    Sptr::from_str(&s).map(SpaceOrPtr::Ptr)
+                    Sptr::from_str(&s).map(Subject::Ptr)
                         .map_err(|e| ClientError::Custom(format!("Invalid SPTR '{}': {}", s, e)))
+                } else if s.starts_with('#') {
+                    SNumeric::from_str(&s).map(Subject::Numeric)
+                        .map_err(|e| ClientError::Custom(format!("Invalid numeric '{}': {}", s, e)))
                 } else {
-                    // Normalize and parse as space
                     let normalized = normalize_space(&s);
-                    SLabel::from_str(&normalized).map(SpaceOrPtr::Space)
+                    SLabel::from_str(&normalized).map(Subject::Space)
                         .map_err(|e| ClientError::Custom(format!("Invalid space '{}': {}", s, e)))
                 }
             }).collect();
@@ -857,7 +860,7 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
             .await?
         }
         Commands::SetRawFallback {
-            space_or_sptr,
+            subject: subject_str,
             data,
             fee_rate,
         } => {
@@ -871,35 +874,21 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
                 }
             };
 
-            // Check if it's an SPTR (starts with "sptr1")
-            if space_or_sptr.starts_with("sptr1") {
-                let sptr = Sptr::from_str(&space_or_sptr).map_err(|e| {
-                    ClientError::Custom(format!("Invalid SPTR: {}", e))
-                })?;
-                cli.send_request(
-                    Some(RpcWalletRequest::SetPtrData(SetPtrDataParams { sptr, data })),
-                    None,
-                    fee_rate,
-                    false,
-                )
-                .await?;
-            } else {
-                // TODO: support set data for spaces
-                // // Space fallback: use existing space script
-                // let space = normalize_space(&space_or_sptr);
-                // let space_script =
-                //     spaces_protocol::script::create_set_data(data.as_slice());
-                //
-                // cli.send_request(
-                //     Some(RpcWalletRequest::Execute(ExecuteParams {
-                //         context: vec![space],
-                //         space_script,
-                //     })),
-                //     None,
-                //     fee_rate,
-                //     false,
-                // )
-                // .await?;
+            let subject = parse_subject(&subject_str)
+                .map_err(|e| ClientError::Custom(format!("Invalid subject: {}", e)))?;
+            match &subject {
+                Subject::Ptr(_) | Subject::Numeric(_) => {
+                    cli.send_request(
+                        Some(RpcWalletRequest::SetPtrData(SetPtrDataParams { subject, data })),
+                        None,
+                        fee_rate,
+                        false,
+                    )
+                    .await?;
+                }
+                Subject::Space(_) => {
+                    // TODO: support set data for spaces
+                }
             }
         }
         Commands::ListUnspent => {
@@ -1070,11 +1059,11 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
                 Some(space) => space,
             };
 
-            let space_or_ptr = parse_space_or_ptr(&space)
-                .map_err(|e| ClientError::Custom(format!("Invalid space or sptr: {}", e)))?;
+            let subject = parse_subject(&space)
+                .map_err(|e| ClientError::Custom(format!("Invalid subject: {}", e)))?;
             let mut event = cli
                 .client
-                .verify_event(space_or_ptr, event)
+                .verify_event(subject, event)
                 .await
                 .map_err(|e| ClientError::Custom(e.to_string()))?;
             event.proof = None;
@@ -1085,11 +1074,11 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
         Commands::VerifyEvent { space, input } => {
             let event = read_event(input)
                 .map_err(|e| ClientError::Custom(format!("input error: {}", e.to_string())))?;
-            let space_or_ptr = parse_space_or_ptr(&space)
-                .map_err(|e| ClientError::Custom(format!("Invalid space or sptr: {}", e)))?;
+            let subject = parse_subject(&space)
+                .map_err(|e| ClientError::Custom(format!("Invalid subject: {}", e)))?;
             let event = cli
                 .client
-                .verify_event(space_or_ptr, event)
+                .verify_event(subject, event)
                 .await
                 .map_err(|e| ClientError::Custom(e.to_string()))?;
 
@@ -1112,12 +1101,11 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
                 .await?
         }
         Commands::GetPtr { spk } => {
-            let sptr = Sptr::from_str(&spk)
-                .map_err(|e| ClientError::Custom(format!("input error: {}", e.to_string())))?;
-
+            let subject = parse_subject(&spk)
+                .map_err(|e| ClientError::Custom(format!("input error: {}", e)))?;
             let ptr = cli
                 .client
-                .get_ptr(sptr)
+                .get_ptr(subject)
                 .await
                 .map_err(|e| ClientError::Custom(e.to_string()))?;
             println!("{}", serde_json::to_string(&ptr).expect("result"));
@@ -1207,7 +1195,6 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
                 None => return Err(ClientError::Custom("no such space".to_string()))
             };
 
-            use spaces_client::rpc::SpaceOrPtr;
             let label = space_info.spaceout.space.as_ref().expect("space").name.clone();
             let delegation = cli.client.get_delegation(label.clone()).await?;
             if delegation.is_none() {
@@ -1217,7 +1204,7 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
 
             cli.send_request(
                 Some(RpcWalletRequest::Transfer(TransferSpacesParams {
-                    spaces: vec![SpaceOrPtr::Ptr(delegation)],
+                    spaces: vec![Subject::Ptr(delegation)],
                     to: Some(to),
                     data: None,
                 })),
@@ -1228,9 +1215,11 @@ async fn handle_commands(cli: &SpaceCli, command: Commands) -> Result<(), Client
                 .await?;
         }
         Commands::GetDelegator { sptr } => {
+            let subject = parse_subject(&sptr)
+                .map_err(|e| ClientError::Custom(format!("Invalid subject: {}", e)))?;
             let delegator = cli
                 .client
-                .get_delegator(sptr)
+                .get_delegator(subject)
                 .await
                 .map_err(|e| ClientError::Custom(e.to_string()))?;
             println!("{}", serde_json::to_string(&delegator).expect("result"));

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -351,11 +351,9 @@ impl Client {
             };
 
             // Ptr => Outpoint + Numeric => Sptr
-            if let Some(ptr) = create.sptr.as_ref() {
-                state.insert_ptr(ptr.id, outpoint.into());
-                let numeric_key = NumericKey::from_numeric::<Sha256>(&ptr.numeric);
-                state.insert_numeric(numeric_key, ptr.id);
-            }
+            state.insert_ptr(create.sptr.id, outpoint.into());
+            let numeric_key = NumericKey::from_numeric::<Sha256>(&create.sptr.numeric);
+            state.insert_numeric(numeric_key, create.sptr.id);
 
             // Outpoint => PtrOut
             let outpoint_key = PtrOutpointKey::from_outpoint::<Sha256>(outpoint);

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -15,7 +15,7 @@ use spaces_protocol::{
     validate::{TxChangeSet, UpdateKind, Validator},
     Bytes, Covenant, FullSpaceOut, RevokeReason, SpaceOut,
 };
-use spaces_ptr::{CommitmentKey, RegistryKey, RegistrySptrKey, PtrOutpointKey};
+use spaces_ptr::{CommitmentKey, NumericKey, RegistryKey, RegistrySptrKey, PtrOutpointKey};
 use spaces_wallet::bitcoin::{Network, Transaction};
 
 use crate::{
@@ -268,7 +268,7 @@ impl Client {
                     .map(|input| input.sstxo.previous_output).collect::<Vec<_>>();
                 let created_spaceouts = spaceouts.unwrap_or_default();
                 let ptrs_validated = self.ptr_validator
-                    .process::<Sha256>(height, &tx, ptrs_ctx, spent_spaceouts, created_spaceouts);
+                    .process::<Sha256>(height, &tx, position as _, ptrs_ctx, spent_spaceouts, created_spaceouts);
 
                 if let Some(idx) = ptr_meta.as_mut() {
                     {
@@ -350,9 +350,11 @@ impl Client {
                 vout: create.n as u32,
             };
 
-            // Ptr => Outpoint
+            // Ptr => Outpoint + Numeric => Sptr
             if let Some(ptr) = create.sptr.as_ref() {
                 state.insert_ptr(ptr.id, outpoint.into());
+                let numeric_key = NumericKey::from_numeric::<Sha256>(&ptr.numeric);
+                state.insert_numeric(numeric_key, ptr.id);
             }
 
             // Outpoint => PtrOut

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -2,7 +2,7 @@ use std::{
     collections::BTreeMap, fs, fs::File, io::Write, net::SocketAddr, path::PathBuf, str::FromStr,
     sync::Arc,
 };
-
+use std::collections::HashSet;
 use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::{Amount, BlockHash, FeeRate, Network, Txid},
@@ -21,7 +21,7 @@ use jsonrpsee::{
     types::ErrorObjectOwned,
 };
 use log::info;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use spacedb::tx::ProofType;
 use spaces_protocol::{
     bitcoin,
@@ -43,13 +43,14 @@ use spaces_wallet::{
     export::WalletExport, nostr::NostrEvent, Balance, DoubleUtxo, Listing, SpacesWallet,
     WalletConfig, WalletDescriptors, WalletOutput,
 };
+pub use spaces_wallet::Subject;
 use tokio::{
     select,
     sync::{broadcast, mpsc, oneshot, RwLock},
     task::JoinSet,
 };
 use spaces_protocol::hasher::Hash;
-use spaces_ptr::{PtrSource, FullPtrOut, PtrOut, Commitment, RegistryKey, CommitmentKey, RegistrySptrKey, PtrOutpointKey, RootAnchor, ChainProofRequest, PtrKeyKind};
+use spaces_ptr::{PtrSource, FullPtrOut, NumericKey, PtrOut, Commitment, RegistryKey, CommitmentKey, RegistrySptrKey, PtrOutpointKey, RootAnchor, ChainProofRequest, PtrKeyKind};
 use spaces_ptr::sptr::Sptr;
 use spaces_wallet::bitcoin::hashes::sha256;
 use crate::auth::BasicAuthLayer;
@@ -139,15 +140,15 @@ pub enum ChainStateCommand {
         resp: Responder<anyhow::Result<Option<Sptr>>>,
     },
     GetDelegator {
-        sptr: Sptr,
+        subject: Subject,
         resp: Responder<anyhow::Result<Option<SLabel>>>,
     },
     GetPtr {
-        hash: Sptr,
+        subject: Subject,
         resp: Responder<anyhow::Result<Option<FullPtrOut>>>,
     },
     GetPtrOutpoint {
-        hash: Sptr,
+        subject: Subject,
         resp: Responder<anyhow::Result<Option<OutPoint>>>,
     },
     GetPtrOut {
@@ -179,12 +180,12 @@ pub enum ChainStateCommand {
         resp: Responder<anyhow::Result<()>>,
     },
     VerifyEvent {
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         event: NostrEvent,
         resp: Responder<anyhow::Result<NostrEvent>>,
     },
     VerifySchnorr {
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         message: Vec<u8>,
         signature: Vec<u8>,
         resp: Responder<anyhow::Result<()>>,
@@ -204,7 +205,7 @@ pub enum ChainStateCommand {
         resp: Responder<anyhow::Result<ProofResult>>,
     },
     ProvePtrOutpoint {
-        sptr: Sptr,
+        subject: Subject,
         prefer_recent: bool,
         resp: Responder<anyhow::Result<ProofResult>>,
     },
@@ -221,7 +222,7 @@ pub enum ChainStateCommand {
         resp: Responder<anyhow::Result<CertificateProofResult>>,
     },
     ProvePtrCertificate {
-        sptr: Sptr,
+        subject: Subject,
         target_block_height: u32,
         resp: Responder<anyhow::Result<PtrCertificateResult>>,
     },
@@ -269,13 +270,13 @@ pub trait Rpc {
     #[method(name = "getptr")]
     async fn get_ptr(
         &self,
-        ptr: Sptr,
+        subject: Subject,
     ) -> Result<Option<FullPtrOut>, ErrorObjectOwned>;
 
     #[method(name = "getptrowner")]
     async fn get_ptr_owner(
         &self,
-        ptr: Sptr,
+        subject: Subject,
     ) -> Result<Option<OutPoint>, ErrorObjectOwned>;
 
     #[method(name = "getptrout")]
@@ -288,7 +289,7 @@ pub trait Rpc {
     async fn get_delegation(&self, space: SLabel) -> Result<Option<Sptr>, ErrorObjectOwned>;
 
     #[method(name = "getdelegator")]
-    async fn get_delegator(&self, sptr: Sptr) -> Result<Option<SLabel>, ErrorObjectOwned>;
+    async fn get_delegator(&self, subject: Subject) -> Result<Option<SLabel>, ErrorObjectOwned>;
 
     #[method(name = "checkpackage")]
     async fn check_package(
@@ -329,7 +330,7 @@ pub trait Rpc {
     #[method(name = "verifyevent")]
     async fn verify_event(
         &self,
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         event: NostrEvent,
     ) -> Result<NostrEvent, ErrorObjectOwned>;
 
@@ -337,7 +338,7 @@ pub trait Rpc {
     async fn wallet_sign_event(
         &self,
         wallet: &str,
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         event: NostrEvent,
     ) -> Result<NostrEvent, ErrorObjectOwned>;
 
@@ -345,7 +346,7 @@ pub trait Rpc {
     async fn wallet_sign_schnorr(
         &self,
         wallet: &str,
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         message: Bytes,
     ) -> Result<Bytes, ErrorObjectOwned>;
 
@@ -359,7 +360,7 @@ pub trait Rpc {
     #[method(name = "verifyschnorr")]
     async fn verify_schnorr(
         &self,
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         message: Bytes,
         signature: Bytes,
     ) -> Result<bool, ErrorObjectOwned>;
@@ -443,7 +444,7 @@ pub trait Rpc {
     #[method(name = "proveptroutpoint")]
     async fn prove_ptr_outpoint(
         &self,
-        sptr: Sptr,
+        subject: Subject,
         prefer_recent: Option<bool>,
     ) -> Result<ProofResult, ErrorObjectOwned>;
 
@@ -466,7 +467,7 @@ pub trait Rpc {
     #[method(name = "proveptrcertificate")]
     async fn prove_ptr_certificate(
         &self,
-        sptr: Sptr,
+        subject: Subject,
         target_block_height: u32,
     ) -> Result<PtrCertificateResult, ErrorObjectOwned>;
 
@@ -554,50 +555,10 @@ pub enum RpcWalletRequest {
     SendCoins(SendCoinsParams),
 }
 
-/// Either a space name or a PTR
-#[derive(Clone, Debug)]
-pub enum SpaceOrPtr {
-    Space(SLabel),
-    Ptr(Sptr),
-}
-
-impl Serialize for SpaceOrPtr {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self {
-            SpaceOrPtr::Space(label) => serializer.serialize_str(&label.to_string()),
-            SpaceOrPtr::Ptr(sptr) => serializer.serialize_str(&sptr.to_string()),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for SpaceOrPtr {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-
-        // Try to parse as SPTR first (starts with "sptr1")
-        if s.starts_with("sptr1") {
-            Sptr::from_str(&s)
-                .map(SpaceOrPtr::Ptr)
-                .map_err(serde::de::Error::custom)
-        } else {
-            // Otherwise parse as space name
-            SLabel::from_str(&s)
-                .map(SpaceOrPtr::Space)
-                .map_err(serde::de::Error::custom)
-        }
-    }
-}
-
 #[derive(Clone, Serialize, Deserialize)]
 pub struct TransferSpacesParams {
     /// List of spaces and/or PTRs to transfer
-    pub spaces: Vec<SpaceOrPtr>,
+    pub spaces: Vec<Subject>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub to: Option<String>,
@@ -624,7 +585,7 @@ pub struct CommitParams {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SetPtrDataParams {
-    pub sptr: Sptr,
+    pub subject: Subject,
     pub data: Vec<u8>,
 }
 
@@ -1108,19 +1069,19 @@ impl RpcServer for RpcServerImpl {
         Ok(spaceout)
     }
 
-    async fn get_ptr(&self, sptr: Sptr) -> Result<Option<FullPtrOut>, ErrorObjectOwned> {
+    async fn get_ptr(&self, subject: Subject) -> Result<Option<FullPtrOut>, ErrorObjectOwned> {
         let info = self
             .store
-            .get_ptr(sptr)
+            .get_ptr(subject)
             .await
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))?;
         Ok(info)
     }
 
-    async fn get_ptr_owner(&self, sptr: Sptr) -> Result<Option<OutPoint>, ErrorObjectOwned> {
+    async fn get_ptr_owner(&self, subject: Subject) -> Result<Option<OutPoint>, ErrorObjectOwned> {
         let info = self
             .store
-            .get_ptr_outpoint(sptr)
+            .get_ptr_outpoint(subject)
             .await
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))?;
         Ok(info)
@@ -1153,10 +1114,10 @@ impl RpcServer for RpcServerImpl {
         Ok(delegation)
     }
 
-    async fn get_delegator(&self, sptr: Sptr) -> Result<Option<SLabel>, ErrorObjectOwned> {
+    async fn get_delegator(&self, subject: Subject) -> Result<Option<SLabel>, ErrorObjectOwned> {
         let delegator = self
             .store
-            .get_delegator(sptr)
+            .get_delegator(subject)
             .await
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))?;
         Ok(delegator)
@@ -1255,11 +1216,11 @@ impl RpcServer for RpcServerImpl {
 
     async fn verify_event(
         &self,
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         event: NostrEvent,
     ) -> Result<NostrEvent, ErrorObjectOwned> {
         self.store
-            .verify_event(space_or_sptr, event)
+            .verify_event(subject, event)
             .await
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
     }
@@ -1267,12 +1228,12 @@ impl RpcServer for RpcServerImpl {
     async fn wallet_sign_event(
         &self,
         wallet: &str,
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         event: NostrEvent,
     ) -> Result<NostrEvent, ErrorObjectOwned> {
         self.wallet(&wallet)
             .await?
-            .send_sign_event(space_or_sptr, event)
+            .send_sign_event(subject, event)
             .await
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
     }
@@ -1280,12 +1241,12 @@ impl RpcServer for RpcServerImpl {
     async fn wallet_sign_schnorr(
         &self,
         wallet: &str,
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         message: Bytes,
     ) -> Result<Bytes, ErrorObjectOwned> {
         self.wallet(&wallet)
             .await?
-            .send_sign_schnorr(space_or_sptr, message.to_vec())
+            .send_sign_schnorr(subject, message.to_vec())
             .await
             .map(|sig| Bytes::new(sig.as_ref().to_vec()))
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
@@ -1305,12 +1266,12 @@ impl RpcServer for RpcServerImpl {
 
     async fn verify_schnorr(
         &self,
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         message: Bytes,
         signature: Bytes,
     ) -> Result<bool, ErrorObjectOwned> {
         self.store
-            .verify_schnorr(space_or_sptr, message.to_vec(), signature.to_vec())
+            .verify_schnorr(subject, message.to_vec(), signature.to_vec())
             .await
             .map(|_| true)
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
@@ -1461,11 +1422,11 @@ impl RpcServer for RpcServerImpl {
 
     async fn prove_ptr_outpoint(
         &self,
-        sptr: Sptr,
+        subject: Subject,
         prefer_recent: Option<bool>,
     ) -> Result<ProofResult, ErrorObjectOwned> {
         self.store
-            .prove_ptr_outpoint(sptr, prefer_recent.unwrap_or(false))
+            .prove_ptr_outpoint(subject, prefer_recent.unwrap_or(false))
             .await
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
     }
@@ -1500,11 +1461,11 @@ impl RpcServer for RpcServerImpl {
 
     async fn prove_ptr_certificate(
         &self,
-        sptr: Sptr,
+        subject: Subject,
         target_block_height: u32,
     ) -> Result<PtrCertificateResult, ErrorObjectOwned> {
         self.store
-            .prove_ptr_certificate(sptr, target_block_height)
+            .prove_ptr_certificate(subject, target_block_height)
             .await
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))
     }
@@ -1783,14 +1744,14 @@ impl AsyncChainState {
                     .context("could not fetch spaceout");
                 let _ = resp.send(result);
             }
-            ChainStateCommand::GetPtr { hash, resp } => {
-                let result = state.get_ptr_info(&hash);
+            ChainStateCommand::GetPtr { subject, resp } => {
+                let result = resolve_sptr(state, &subject)
+                    .and_then(|sptr| state.get_ptr_info(&sptr));
                 let _ = resp.send(result);
             }
-            ChainStateCommand::GetPtrOutpoint { hash, resp } => {
-                let result = state
-                    .get_ptr_outpoint(&hash)
-                    .context("could not fetch ptrout");
+            ChainStateCommand::GetPtrOutpoint { subject, resp } => {
+                let result = resolve_sptr(state, &subject)
+                    .and_then(|sptr| state.get_ptr_outpoint(&sptr).context("could not fetch ptrout"));
                 let _ = resp.send(result);
             }
             ChainStateCommand::GetCommitment { space, root, resp } => {
@@ -1801,9 +1762,10 @@ impl AsyncChainState {
                 let result = get_delegation(state, space);
                 let _ = resp.send(result);
             }
-            ChainStateCommand::GetDelegator { sptr, resp } => {
-                let result = state
-                    .get_delegator(&RegistrySptrKey::from_sptr::<Sha256>(sptr)).map_err(|e| anyhow!("could not get delegator: {}", e));
+            ChainStateCommand::GetDelegator { subject, resp } => {
+                let result = resolve_sptr(state, &subject)
+                    .and_then(|sptr| state.get_delegator(&RegistrySptrKey::from_sptr::<Sha256>(sptr))
+                        .map_err(|e| anyhow!("could not get delegator: {}", e)));
                 let _ = resp.send(result);
             }
             ChainStateCommand::GetPtrOut { outpoint, resp } => {
@@ -1847,26 +1809,15 @@ impl AsyncChainState {
                     SpacesWallet::verify_listing::<Sha256>(state, &listing).map(|_| ()),
                 );
             }
-            ChainStateCommand::VerifyEvent { space_or_sptr, event, resp } => {
-                let space_or_sptr = match space_or_sptr {
-                    SpaceOrPtr::Space(label) => spaces_wallet::SpaceOrSptr::Space(label),
-                    SpaceOrPtr::Ptr(sptr) => spaces_wallet::SpaceOrSptr::Sptr(sptr),
-                };
-                _ = resp.send(SpacesWallet::verify_event::<Sha256, _>(
-                    state,
-                    space_or_sptr,
-                    event,
-                ));
+            ChainStateCommand::VerifyEvent { subject, event, resp } => {
+                let result = SpacesWallet::verify_event::<Sha256, _>(state, subject, event);
+                _ = resp.send(result);
             }
-            ChainStateCommand::VerifySchnorr { space_or_sptr, message, signature, resp } => {
+            ChainStateCommand::VerifySchnorr { subject, message, signature, resp } => {
                 let result = (|| {
-                    let space_or_sptr = match space_or_sptr {
-                        SpaceOrPtr::Space(label) => spaces_wallet::SpaceOrSptr::Space(label),
-                        SpaceOrPtr::Ptr(sptr) => spaces_wallet::SpaceOrSptr::Sptr(sptr),
-                    };
                     let sig = schnorr::Signature::from_slice(&signature)
                         .map_err(|_| anyhow!("Invalid signature format"))?;
-                    SpacesWallet::verify_schnorr::<Sha256, _>(state, space_or_sptr, &message, &sig)
+                    SpacesWallet::verify_schnorr::<Sha256, _>(state, subject, &message, &sig)
                 })();
                 _ = resp.send(result);
             }
@@ -1902,15 +1853,13 @@ impl AsyncChainState {
                 ));
             }
             ChainStateCommand::ProvePtrOutpoint {
-                sptr,
+                subject,
                 prefer_recent,
                 resp,
             } => {
-                _ = resp.send(Self::handle_prove_ptr_outpoint(
-                    state,
-                    sptr,
-                    prefer_recent,
-                ));
+                let result = resolve_sptr(state, &subject)
+                    .and_then(|sptr| Self::handle_prove_ptr_outpoint(state, sptr, prefer_recent));
+                _ = resp.send(result);
             }
             ChainStateCommand::ProveCommitment {
                 space,
@@ -1939,15 +1888,13 @@ impl AsyncChainState {
                 ));
             }
             ChainStateCommand::ProvePtrCertificate {
-                sptr,
+                subject,
                 target_block_height,
                 resp,
             } => {
-                _ = resp.send(Self::handle_prove_ptr_certificate(
-                    state,
-                    sptr,
-                    target_block_height,
-                ));
+                let result = resolve_sptr(state, &subject)
+                    .and_then(|sptr| Self::handle_prove_ptr_certificate(state, sptr, target_block_height));
+                _ = resp.send(result);
             }
             ChainStateCommand::BuildChainProof {
                 request,
@@ -2142,10 +2089,7 @@ impl AsyncChainState {
                     ))
                 }
             };
-            let last_update = ptr_info.ptrout.sptr
-                .as_ref()
-                .map(|p| p.last_update)
-                .unwrap_or(0);
+            let last_update = ptr_info.ptrout.sptr.last_update;
             let tip = state.ptrs_tip();
             let target_snapshot = Self::compute_target_snapshot(last_update, tip.height);
             state.prove_ptrs_with_snapshot(&[key], target_snapshot)?.1
@@ -2180,18 +2124,8 @@ impl AsyncChainState {
                     ))
                 }
             };
-            // Use the last_update height from the PTR to find an appropriate snapshot
-            let target_snapshot = match &ptrout.sptr {
-                Some(ptr) => {
-                    let tip = state.ptrs_tip();
-                    Self::compute_target_snapshot(ptr.last_update, tip.height)
-                }
-                None => {
-                    return Err(anyhow!(
-                        "Cannot find older proofs for a UTXO without PTR data (try with prefer_recent: true)"
-                    ))
-                }
-            };
+            let tip = state.ptrs_tip();
+            let target_snapshot = Self::compute_target_snapshot(ptrout.sptr.last_update, tip.height);
             state.prove_ptrs_with_snapshot(&[key.into()], target_snapshot)?.1
         } else {
             let snapshot = state.ptrs_mut().state.inner()?;
@@ -2251,15 +2185,20 @@ impl AsyncChainState {
         prefer_recent: bool,
     ) -> anyhow::Result<ChainProofResult> {
         let mut most_recent_update = 0u32;
-        let mut space_tree_keys: Vec<Hash> = Vec::new();
-        let mut ptr_tree_keys: Vec<Hash> = Vec::new();
+        let mut space_tree_keys: HashSet<Hash> = HashSet::new();
+        let mut ptr_tree_keys: HashSet<Hash> = HashSet::new();
 
         for space in request.spaces {
+            if space.is_numeric() {
+                request.ptrs_keys.push(PtrKeyKind::Numeric(space.try_into()?));
+                continue;
+            }
+
             let space_key = SpaceKey::from(Sha256::hash(space.as_ref()));
             let fso = state.get_space_info(&space_key)?
                 .ok_or_else(|| anyhow!("Space not found: {}", space))?;
 
-            space_tree_keys.push(space_key.into());
+            space_tree_keys.insert(space_key.into());
             if let Some(space) = &fso.spaceout.space {
                 if let Covenant::Transfer { expire_height, .. } = &space.covenant {
                     let last_update = expire_height
@@ -2274,26 +2213,40 @@ impl AsyncChainState {
 
         for key in request.ptrs_keys {
             match key {
-                PtrKeyKind::Sptr(sptr) => {
-                    let fpt = state.get_ptr_info(&sptr)?;
-                    if let Some(fpt) = fpt {
-                        if let Some(ptr) = &fpt.ptrout.sptr {
-                            ptr_tree_keys.push(
-                                PtrOutpointKey::from_outpoint::<Sha256>(fpt.outpoint()).into()
-                            );
-                            most_recent_update = std::cmp::max(most_recent_update, ptr.last_update);
-                        } else {
-                            ptr_tree_keys.push(sptr.into());
-                        }
+                PtrKeyKind::Numeric(numeric) => {
+                    let key = NumericKey::from_numeric::<Sha256>(&numeric);
+                    let sptr = state.get_numeric(&key)?;
+                    if let Some(sptr) = sptr {
+                        let fpt = state.get_ptr_info(&sptr)?
+                            .expect("sptr must exist if numeric exists");
+                        ptr_tree_keys.insert(
+                            PtrOutpointKey::from_outpoint::<Sha256>(fpt.outpoint()).into()
+                        );
+                        most_recent_update = std::cmp::max(most_recent_update, fpt.ptrout.sptr.last_update);
                     } else {
                         // non-existence proof
-                        ptr_tree_keys.push(sptr.into());
+                        ptr_tree_keys.insert(key.into());
                     }
                 }
-                PtrKeyKind::Commitment(k) => ptr_tree_keys.push(k.into()),
-                PtrKeyKind::Registry(k) => ptr_tree_keys.push(k.into()),
+                PtrKeyKind::Sptr(sptr) => {
+                    let fpt = state.get_ptr_info(&sptr)?
+                        .expect("sptr must exist if referenced");
+                    ptr_tree_keys.insert(
+                        PtrOutpointKey::from_outpoint::<Sha256>(fpt.outpoint()).into()
+                    );
+                    most_recent_update = std::cmp::max(most_recent_update, fpt.ptrout.sptr.last_update);
+                }
+                PtrKeyKind::Commitment(k) => {
+                    ptr_tree_keys.insert(k.into());
+                },
+                PtrKeyKind::Registry(k) => {
+                    ptr_tree_keys.insert(k.into());
+                },
             }
         }
+
+        let ptr_tree_keys : Vec<_> = ptr_tree_keys.into_iter().collect();
+        let space_tree_keys : Vec<_> = space_tree_keys.into_iter().collect();
 
         let (spaces_proof, spaces_root, block_anchor, ptrs_proof, ptrs_root) = if prefer_recent {
             let spaces_snapshot = state.spaces_inner()?;
@@ -2446,9 +2399,7 @@ impl AsyncChainState {
 
             // Check ptrout last update if present
             if let Some(ref ptr) = ptrout {
-                if let Some(ref ptr_data) = ptr.sptr {
-                    most_recent_update = std::cmp::max(most_recent_update, ptr_data.last_update);
-                }
+                most_recent_update = std::cmp::max(most_recent_update, ptr.sptr.last_update);
             }
 
             // Check commitment block height if present
@@ -2590,11 +2541,11 @@ impl AsyncChainState {
         resp_rx.await?
     }
 
-    pub async fn verify_event(&self, space_or_sptr: SpaceOrPtr, event: NostrEvent) -> anyhow::Result<NostrEvent> {
+    pub async fn verify_event(&self, subject: Subject, event: NostrEvent) -> anyhow::Result<NostrEvent> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
             .send(ChainStateCommand::VerifyEvent {
-                space_or_sptr,
+                subject,
                 event,
                 resp,
             })
@@ -2604,14 +2555,14 @@ impl AsyncChainState {
 
     pub async fn verify_schnorr(
         &self,
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         message: Vec<u8>,
         signature: Vec<u8>,
     ) -> anyhow::Result<()> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
             .send(ChainStateCommand::VerifySchnorr {
-                space_or_sptr,
+                subject,
                 message,
                 signature,
                 resp,
@@ -2663,11 +2614,11 @@ impl AsyncChainState {
         resp_rx.await?
     }
 
-    pub async fn prove_ptr_outpoint(&self, sptr: Sptr, prefer_recent: bool) -> anyhow::Result<ProofResult> {
+    pub async fn prove_ptr_outpoint(&self, subject: Subject, prefer_recent: bool) -> anyhow::Result<ProofResult> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
             .send(ChainStateCommand::ProvePtrOutpoint {
-                sptr,
+                subject,
                 prefer_recent,
                 resp,
             })
@@ -2713,13 +2664,13 @@ impl AsyncChainState {
 
     pub async fn prove_ptr_certificate(
         &self,
-        sptr: Sptr,
+        subject: Subject,
         target_block_height: u32,
     ) -> anyhow::Result<PtrCertificateResult> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
             .send(ChainStateCommand::ProvePtrCertificate {
-                sptr,
+                subject,
                 target_block_height,
                 resp,
             })
@@ -2775,10 +2726,10 @@ impl AsyncChainState {
         resp_rx.await?
     }
 
-    pub async fn get_ptr(&self, hash: Sptr) -> anyhow::Result<Option<FullPtrOut>> {
+    pub async fn get_ptr(&self, subject: Subject) -> anyhow::Result<Option<FullPtrOut>> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
-            .send(ChainStateCommand::GetPtr { hash, resp })
+            .send(ChainStateCommand::GetPtr { subject, resp })
             .await?;
         resp_rx.await?
     }
@@ -2791,10 +2742,10 @@ impl AsyncChainState {
         resp_rx.await?
     }
 
-    pub async fn get_ptr_outpoint(&self, hash: Sptr) -> anyhow::Result<Option<OutPoint>> {
+    pub async fn get_ptr_outpoint(&self, subject: Subject) -> anyhow::Result<Option<OutPoint>> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
-            .send(ChainStateCommand::GetPtrOutpoint { hash, resp })
+            .send(ChainStateCommand::GetPtrOutpoint { subject, resp })
             .await?;
         resp_rx.await?
     }
@@ -2850,10 +2801,10 @@ impl AsyncChainState {
         resp_rx.await?
     }
 
-    pub async fn get_delegator(&self, sptr: Sptr) -> anyhow::Result<Option<SLabel>> {
+    pub async fn get_delegator(&self, subject: Subject) -> anyhow::Result<Option<SLabel>> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
-            .send(ChainStateCommand::GetDelegator { sptr, resp })
+            .send(ChainStateCommand::GetDelegator { subject, resp })
             .await?;
         resp_rx.await?
     }
@@ -2892,6 +2843,18 @@ impl AsyncChainState {
             .send(ChainStateCommand::GetTxMeta { txid, resp })
             .await?;
         resp_rx.await?
+    }
+}
+
+fn resolve_sptr(state: &mut Chain, subject: &Subject) -> anyhow::Result<Sptr> {
+    match subject {
+        Subject::Ptr(sptr) => Ok(*sptr),
+        Subject::Numeric(numeric) => {
+            let key = NumericKey::from_numeric::<Sha256>(numeric);
+            state.get_numeric(&key)?
+                .ok_or_else(|| anyhow!("numeric '{}' not found", numeric))
+        }
+        Subject::Space(_) => Err(anyhow!("expected a ptr or numeric, not a space")),
     }
 }
 

--- a/client/src/store/chain.rs
+++ b/client/src/store/chain.rs
@@ -10,7 +10,7 @@ use spaces_protocol::hasher::{BaseHash, BidKey, OutpointKey, SpaceKey};
 use spaces_protocol::prepare::SpacesSource;
 use spaces_protocol::{FullSpaceOut, SpaceOut};
 use spaces_protocol::slabel::SLabel;
-use spaces_ptr::{Commitment, CommitmentKey, FullPtrOut, PtrOut, PtrSource, RegistryKey, RegistrySptrKey, PtrOutpointKey, RootAnchor};
+use spaces_ptr::{Commitment, CommitmentKey, FullPtrOut, NumericKey, PtrOut, PtrSource, RegistryKey, RegistrySptrKey, PtrOutpointKey, RootAnchor};
 use spaces_ptr::sptr::Sptr;
 use spaces_wallet::bitcoin::Network;
 use crate::client::{BlockMeta, PtrBlockMeta};
@@ -83,6 +83,10 @@ impl PtrSource for Chain {
 
     fn get_ptrout(&mut self, outpoint: &OutPoint) -> spaces_protocol::errors::Result<Option<PtrOut>> {
         self.db.pt.state.get_ptrout(outpoint)
+    }
+
+    fn get_numeric(&mut self, key: &NumericKey) -> spaces_protocol::errors::Result<Option<Sptr>> {
+        self.db.pt.state.get_numeric(key)
     }
 }
 
@@ -282,6 +286,10 @@ impl Chain {
 
     pub(crate) fn insert_ptr(&self, key: Sptr, outpoint: EncodableOutpoint) {
         self.db.pt.state.insert(key, outpoint)
+    }
+
+    pub(crate) fn insert_numeric(&self, key: NumericKey, sptr: Sptr) {
+        self.db.pt.state.insert_numeric(key, sptr)
     }
 
     pub(crate) fn insert_delegation(&self, key: RegistrySptrKey, space: SLabel) {

--- a/client/src/store/ptrs.rs
+++ b/client/src/store/ptrs.rs
@@ -23,7 +23,7 @@ use spaces_protocol::{
     hasher::{KeyHash},
 };
 use spaces_protocol::slabel::SLabel;
-use spaces_ptr::{Commitment, CommitmentKey, FullPtrOut, PtrOut, PtrSource, RegistryKey, RegistrySptrKey, PtrOutpointKey};
+use spaces_ptr::{Commitment, CommitmentKey, FullPtrOut, NumericKey, PtrOut, PtrSource, RegistryKey, RegistrySptrKey, PtrOutpointKey};
 use spaces_ptr::sptr::Sptr;
 use crate::store::{EncodableOutpoint, Sha256};
 
@@ -116,6 +116,7 @@ pub trait PtrChainState {
     fn remove_registry(&self, key: RegistryKey);
     fn insert_registry_delegation(&self, key: RegistrySptrKey, space: SLabel);
     fn insert_ptr(&self, key: Sptr, outpoint: EncodableOutpoint);
+    fn insert_numeric(&self, key: NumericKey, sptr: Sptr);
 
     #[allow(dead_code)]
     fn get_ptr_info(
@@ -147,6 +148,10 @@ impl PtrChainState for PtrLiveSnapshot {
 
     fn insert_ptr(&self, key: Sptr, outpoint: EncodableOutpoint) {
         self.insert(key, outpoint)
+    }
+
+    fn insert_numeric(&self, key: NumericKey, sptr: Sptr) {
+        self.insert(key, sptr)
     }
 
     fn get_ptr_info(&mut self, hash: &Sptr) -> Result<Option<FullPtrOut>> {
@@ -362,6 +367,13 @@ impl PtrSource for PtrLiveSnapshot {
         let h = PtrOutpointKey::from_outpoint::<Sha256>(*outpoint);
         let result = self.get(h).map_err(|err| {
             spaces_protocol::errors::Error::IO(format!("getptrout: {}", err.to_string()))
+        })?;
+        Ok(result)
+    }
+
+    fn get_numeric(&mut self, key: &NumericKey) -> spaces_protocol::errors::Result<Option<Sptr>> {
+        let result = self.get(*key).map_err(|err| {
+            spaces_protocol::errors::Error::IO(format!("getnumeric: {}", err.to_string()))
         })?;
         Ok(result)
     }

--- a/client/src/wallets.rs
+++ b/client/src/wallets.rs
@@ -25,7 +25,7 @@ use spaces_wallet::{
     builder::{CoinTransfer, SpaceTransfer, SpacesAwareCoinSelection},
     nostr::NostrEvent,
     tx_event::{TxEvent, TxEventKind, TxRecord},
-    Balance, DoubleUtxo, Listing, SpacesWallet, SpaceOrSptr, WalletInfo, WalletOutput,
+    Balance, DoubleUtxo, Listing, SpacesWallet, Subject, WalletInfo, WalletOutput,
 };
 
 use tabled::Tabled;
@@ -43,7 +43,9 @@ use crate::{calc_progress, checker::TxChecker, client::BlockSource, config::Exte
     BitcoinBlockSource, BitcoinRpc, BitcoinRpcError, BlockEvent, BlockFetchError, BlockFetcher,
 }, std_wait};
 use crate::cbf::{CompactFilterSync};
-use crate::rpc::{CommitParams, SpaceOrPtr};
+use crate::rpc::CommitParams;
+use spaces_ptr::NumericKey;
+use spaces_ptr::snumeric::SNumeric;
 use crate::spaces::Spaced;
 use crate::store::chain::Chain;
 use crate::store::Sha256;
@@ -57,6 +59,7 @@ pub enum ResolvableTarget {
     SpaceAddress(SpaceAddress),
     Address(Address),
     Sptr(Sptr),
+    Numeric(SNumeric),
 }
 
 #[derive(Debug)]
@@ -64,6 +67,7 @@ pub enum ResolvableTargetParseError {
     SpaceLabelParseError(spaces_protocol::errors::Error),
     AddressParseError(ParseError),
     SptrParseError(SptrParseError),
+    NumericParseError(spaces_ptr::snumeric::SNumericParseError),
 }
 
 impl Display for ResolvableTargetParseError {
@@ -72,6 +76,7 @@ impl Display for ResolvableTargetParseError {
             ResolvableTargetParseError::SpaceLabelParseError(e) => write!(f, "{}", e),
             ResolvableTargetParseError::AddressParseError(e) => write!(f, "{}", e),
             ResolvableTargetParseError::SptrParseError(e) => write!(f, "{}", e),
+            ResolvableTargetParseError::NumericParseError(e) => write!(f, "{}", e),
         }
     }
 }
@@ -93,6 +98,11 @@ impl FromStr for ResolvableTarget {
                 .map(ResolvableTarget::Sptr)
                 .map_err(ResolvableTargetParseError::SptrParseError);
         }
+        if s.starts_with('#') {
+            return SNumeric::from_str(s)
+                .map(ResolvableTarget::Numeric)
+                .map_err(ResolvableTargetParseError::NumericParseError);
+        }
 
         match SpaceAddress::from_str(s) {
             Ok(addr) => Ok(ResolvableTarget::SpaceAddress(addr)),
@@ -110,6 +120,7 @@ impl fmt::Display for ResolvableTarget {
         match self {
             ResolvableTarget::Space(label) => write!(f, "{}", label),
             ResolvableTarget::Sptr(sptr) => write!(f, "{}", sptr),
+            ResolvableTarget::Numeric(num) => write!(f, "{}", num),
             ResolvableTarget::SpaceAddress(addr) => write!(f, "{}", addr),
             ResolvableTarget::Address(addr) => write!(f, "{}", addr),
         }
@@ -281,12 +292,12 @@ pub enum WalletCommand {
     },
     UnloadWallet,
     SignEvent {
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         event: NostrEvent,
         resp: crate::rpc::Responder<anyhow::Result<NostrEvent>>,
     },
     SignSchnorr {
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         message: Vec<u8>,
         resp: crate::rpc::Responder<anyhow::Result<schnorr::Signature>>,
     },
@@ -597,19 +608,11 @@ impl RpcWallet {
             WalletCommand::Sell { space, price, resp } => {
                 _ = resp.send(wallet.sell::<Sha256>(chain, &space, Amount::from_sat(price)));
             }
-            WalletCommand::SignEvent { space_or_sptr, event, resp } => {
-                let space_or_sptr = match space_or_sptr {
-                    SpaceOrPtr::Space(label) => SpaceOrSptr::Space(label),
-                    SpaceOrPtr::Ptr(sptr) => SpaceOrSptr::Sptr(sptr),
-                };
-                _ = resp.send(wallet.sign_event::<Sha256, _>(chain, space_or_sptr, event));
+            WalletCommand::SignEvent { subject, event, resp } => {
+                _ = resp.send(wallet.sign_event::<Sha256, _>(chain, subject, event));
             }
-            WalletCommand::SignSchnorr { space_or_sptr, message, resp } => {
-                let space_or_sptr = match space_or_sptr {
-                    SpaceOrPtr::Space(label) => SpaceOrSptr::Space(label),
-                    SpaceOrPtr::Ptr(sptr) => SpaceOrSptr::Sptr(sptr),
-                };
-                _ = resp.send(wallet.sign_schnorr::<Sha256, _>(chain, space_or_sptr, &message));
+            WalletCommand::SignSchnorr { subject, message, resp } => {
+                _ = resp.send(wallet.sign_schnorr::<Sha256, _>(chain, subject, &message));
             }
             WalletCommand::CanOperate { space, resp } => {
                 let result = Self::can_operate(wallet, chain, space);
@@ -1089,6 +1092,21 @@ impl RpcWallet {
                     network.fallback_network(),
                 )?
             }
+            ResolvableTarget::Numeric(numeric) => {
+                let key = NumericKey::from_numeric::<Sha256>(&numeric);
+                let sptr = match chain.get_numeric(&key)? {
+                    None => return Ok(None),
+                    Some(sptr) => sptr,
+                };
+                let script_pubkey = match chain.get_ptr_info(&sptr)? {
+                    None => return Ok(None),
+                    Some(fullptrout) => fullptrout.ptrout.script_pubkey,
+                };
+                Address::from_script(
+                    script_pubkey.as_script(),
+                    network.fallback_network(),
+                )?
+            }
         };
         Ok(Some(address))
     }
@@ -1167,12 +1185,21 @@ impl RpcWallet {
                         None
                     };
 
-                    // Process each item - either a space or PTR
+                    // Process each item - space, PTR, or numeric
                     for item in &params.spaces {
                         match item {
-                            SpaceOrPtr::Ptr(sptr) => {
+                            Subject::Ptr(_) | Subject::Numeric(_) => {
+                                let sptr = match item {
+                                    Subject::Ptr(s) => *s,
+                                    Subject::Numeric(numeric) => {
+                                        let key = NumericKey::from_numeric::<Sha256>(numeric);
+                                        chain.get_numeric(&key)?
+                                            .ok_or_else(|| anyhow!("transfer: numeric '{}' not found", numeric))?
+                                    }
+                                    _ => unreachable!(),
+                                };
                                 // Handle PTR transfer
-                                let ptr = match chain.get_ptr_info(sptr)? {
+                                let ptr = match chain.get_ptr_info(&sptr)? {
                                     None => return Err(anyhow!("transfer: PTR '{}' not found or not owned", sptr)),
                                     Some(full) if !wallet.is_mine(full.ptrout.script_pubkey.clone()) => {
                                         return Err(anyhow!("transfer: you don't own PTR '{}'", sptr))
@@ -1196,7 +1223,7 @@ impl RpcWallet {
                                     recipient: recipient_addr,
                                 });
                             }
-                            SpaceOrPtr::Space(space) => {
+                            Subject::Space(space) => {
                                 // Handle space transfer
                                 let spacehash = SpaceKey::from(Sha256::hash(space.as_ref()));
                                 match chain.get_space_info(&spacehash)? {
@@ -1407,16 +1434,25 @@ impl RpcWallet {
                     });
                 }
                 RpcWalletRequest::SetPtrData(params) => {
+                    let sptr = match &params.subject {
+                        Subject::Ptr(s) => *s,
+                        Subject::Numeric(numeric) => {
+                            let key = NumericKey::from_numeric::<Sha256>(numeric);
+                            chain.get_numeric(&key)?
+                                .ok_or_else(|| anyhow!("setptrdata: numeric '{}' not found", numeric))?
+                        }
+                        Subject::Space(_) => return Err(anyhow!("setptrdata: expected a ptr or numeric, not a space")),
+                    };
                     // Find the PTR UTXO
-                    let ptr_info = match chain.get_ptr_info(&params.sptr)? {
-                        None => return Err(anyhow!("setptrdata: PTR '{}' not found", params.sptr)),
+                    let ptr_info = match chain.get_ptr_info(&sptr)? {
+                        None => return Err(anyhow!("setptrdata: PTR '{}' not found", sptr)),
                         Some(ptr) if !wallet.is_mine(ptr.ptrout.script_pubkey.clone()) => {
-                            return Err(anyhow!("setptrdata: you don't own '{}'", params.sptr))
+                            return Err(anyhow!("setptrdata: you don't own '{}'", sptr))
                         }
                         Some(ptr) if wallet.get_utxo(OutPoint::new(ptr.txid, ptr.ptrout.n as u32)).is_none() => {
                             return Err(anyhow!(
                                 "setptrdata '{}': wallet already has a pending tx for this PTR",
-                                params.sptr
+                                sptr
                             ))
                         }
                         Some(ptr) => ptr,
@@ -1680,13 +1716,13 @@ impl RpcWallet {
 
     pub async fn send_sign_event(
         &self,
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         event: NostrEvent,
     ) -> anyhow::Result<NostrEvent> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
             .send(WalletCommand::SignEvent {
-                space_or_sptr,
+                subject,
                 event,
                 resp,
             })
@@ -1756,13 +1792,13 @@ impl RpcWallet {
 
     pub async fn send_sign_schnorr(
         &self,
-        space_or_sptr: SpaceOrPtr,
+        subject: Subject,
         message: Vec<u8>,
     ) -> anyhow::Result<schnorr::Signature> {
         let (resp, resp_rx) = oneshot::channel();
         self.sender
             .send(WalletCommand::SignSchnorr {
-                space_or_sptr,
+                subject,
                 message,
                 resp,
             })

--- a/client/tests/integration_tests.rs
+++ b/client/tests/integration_tests.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, str::FromStr};
 use spaces_client::{
     rpc::{
         BidParams, OpenParams, RegisterParams, RpcClient, RpcWalletRequest,
-        RpcWalletTxBuilder, SpaceOrPtr, TransferSpacesParams,
+        RpcWalletTxBuilder, Subject, TransferSpacesParams,
     },
     wallets::{AddressKind, WalletResponse},
 };
@@ -365,7 +365,6 @@ async fn it_should_allow_claim_on_or_after_claim_height(rig: &TestRig) -> anyhow
 async fn it_should_allow_batch_transfers_refreshing_expire_height(
     rig: &TestRig,
 ) -> anyhow::Result<()> {
-    use spaces_client::rpc::SpaceOrPtr;
     use spaces_protocol::slabel::SLabel;
 
     rig.wait_until_wallet_synced(ALICE).await?;
@@ -376,7 +375,7 @@ async fn it_should_allow_batch_transfers_refreshing_expire_height(
         .iter()
         .map(|out| {
             let name = out.spaceout.space.as_ref().expect("space").name.to_string();
-            SpaceOrPtr::Space(SLabel::from_str(&name).expect("valid space"))
+            Subject::Space(SLabel::from_str(&name).expect("valid space"))
         })
         .collect();
 
@@ -437,7 +436,6 @@ async fn it_should_allow_batch_transfers_refreshing_expire_height(
 }
 
 async fn it_should_allow_applying_script_in_batch(rig: &TestRig) -> anyhow::Result<()> {
-    use spaces_client::rpc::SpaceOrPtr;
     use spaces_protocol::slabel::SLabel;
 
     rig.wait_until_wallet_synced(ALICE).await?;
@@ -448,7 +446,7 @@ async fn it_should_allow_applying_script_in_batch(rig: &TestRig) -> anyhow::Resu
         .iter()
         .map(|out| {
             let name = out.spaceout.space.as_ref().expect("space").name.to_string();
-            SpaceOrPtr::Space(SLabel::from_str(&name).expect("valid space"))
+            Subject::Space(SLabel::from_str(&name).expect("valid space"))
         })
         .collect();
 
@@ -862,7 +860,6 @@ async fn it_should_not_allow_register_or_transfer_to_same_space_multiple_times(
         .wallet_get_new_address(BOB, AddressKind::Space)
         .await?;
 
-    use spaces_client::rpc::SpaceOrPtr;
     use spaces_protocol::slabel::SLabel;
 
     let transfer = "@test9995".to_string();
@@ -870,7 +867,7 @@ async fn it_should_not_allow_register_or_transfer_to_same_space_multiple_times(
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(SLabel::from_str(&transfer).expect("valid"))],
+            spaces: vec![Subject::Space(SLabel::from_str(&transfer).expect("valid"))],
             to: Some(bob_address.clone()),
             data: None,
         })],
@@ -888,7 +885,7 @@ async fn it_should_not_allow_register_or_transfer_to_same_space_multiple_times(
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(SLabel::from_str(&transfer).expect("valid"))],
+            spaces: vec![Subject::Space(SLabel::from_str(&transfer).expect("valid"))],
             to: Some(bob_address),
             data: None,
         })],
@@ -902,7 +899,7 @@ async fn it_should_not_allow_register_or_transfer_to_same_space_multiple_times(
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(SLabel::from_str(&setdata).expect("valid"))],
+            spaces: vec![Subject::Space(SLabel::from_str(&setdata).expect("valid"))],
             to: None,
             data: Some(vec![0xAA, 0xAA]),
         })],
@@ -919,7 +916,7 @@ async fn it_should_not_allow_register_or_transfer_to_same_space_multiple_times(
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(SLabel::from_str(&setdata).expect("valid"))],
+            spaces: vec![Subject::Space(SLabel::from_str(&setdata).expect("valid"))],
             to: None,
             data: Some(vec![0xDE, 0xAD]),
         })],
@@ -957,7 +954,6 @@ async fn it_should_not_allow_register_or_transfer_to_same_space_multiple_times(
 }
 
 async fn it_can_batch_txs(rig: &TestRig) -> anyhow::Result<()> {
-    use spaces_client::rpc::SpaceOrPtr;
     use spaces_protocol::slabel::SLabel;
 
     rig.wait_until_wallet_synced(ALICE).await.expect("synced");
@@ -971,7 +967,7 @@ async fn it_can_batch_txs(rig: &TestRig) -> anyhow::Result<()> {
         ALICE,
         vec![
             RpcWalletRequest::Transfer(TransferSpacesParams {
-                spaces: vec![SpaceOrPtr::Space(SLabel::from_str("@test9996").expect("valid"))],
+                spaces: vec![Subject::Space(SLabel::from_str("@test9996").expect("valid"))],
                 to: Some(bob_address),
                 data: None,
             }),
@@ -990,9 +986,9 @@ async fn it_can_batch_txs(rig: &TestRig) -> anyhow::Result<()> {
             // Transfer spaces to self with data (replaces Execute)
             RpcWalletRequest::Transfer(TransferSpacesParams {
                 spaces: vec![
-                    SpaceOrPtr::Space(SLabel::from_str("@test10000").expect("valid")),
-                    SpaceOrPtr::Space(SLabel::from_str("@test9999").expect("valid")),
-                    SpaceOrPtr::Space(SLabel::from_str("@test9998").expect("valid")),
+                    Subject::Space(SLabel::from_str("@test10000").expect("valid")),
+                    Subject::Space(SLabel::from_str("@test9999").expect("valid")),
+                    Subject::Space(SLabel::from_str("@test9998").expect("valid")),
                 ],
                 to: None,
                 data: Some(vec![0xEE, 0xEE, 0x22, 0x22]),
@@ -1235,7 +1231,7 @@ async fn it_should_allow_sign_verify_messages(rig: &TestRig) -> anyhow::Result<(
     let space_name = space.spaceout.space.as_ref().unwrap().name.to_string();
 
     let msg = NostrEvent::new(1, "hello world", vec![]);
-    let space_or_ptr = SpaceOrPtr::Space(SLabel::from_str(&space_name).unwrap());
+    let space_or_ptr = Subject::Space(SLabel::from_str(&space_name).unwrap());
     let signed = rig
         .spaced
         .client
@@ -1290,7 +1286,7 @@ async fn it_should_handle_expired_spaces(rig: &TestRig) -> anyhow::Result<()> {
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(
+            spaces: vec![Subject::Space(
                 SLabel::from_str(&space_name).expect("valid")
             )],
             to: None, // renew to self
@@ -1367,7 +1363,7 @@ async fn it_should_handle_expired_spaces(rig: &TestRig) -> anyhow::Result<()> {
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(
+            spaces: vec![Subject::Space(
                 SLabel::from_str(&space_name_2).expect("valid")
             )],
             to: None,

--- a/client/tests/ptr_tests.rs
+++ b/client/tests/ptr_tests.rs
@@ -9,7 +9,7 @@ use spaces_client::{
     },
     wallets::{AddressKind, WalletResponse},
 };
-use spaces_client::rpc::{CommitParams, CreatePtrParams, DelegateParams, SetPtrDataParams, SpaceOrPtr, TransferSpacesParams};
+use spaces_client::rpc::{CommitParams, CreatePtrParams, DelegateParams, SetPtrDataParams, Subject, TransferSpacesParams};
 use spaces_client::store::Sha256;
 use spaces_protocol::{bitcoin, bitcoin::{FeeRate}};
 use spaces_protocol::bitcoin::hashes::{sha256, Hash};
@@ -111,7 +111,7 @@ async fn it_should_create_sptrs(rig: &TestRig) -> anyhow::Result<()> {
         .script_pubkey();
     let sptr0 = Sptr::from_spk::<Sha256>(spk0.clone());
 
-    let ptr0 = rig.spaced.client.get_ptr(sptr0).await?
+    let ptr0 = rig.spaced.client.get_ptr(Subject::Ptr(sptr0)).await?
         .expect("ptr must exist after first CreatePtr");
     let bound_spk_before = ptr0.ptrout.script_pubkey.clone();
 
@@ -121,7 +121,7 @@ async fn it_should_create_sptrs(rig: &TestRig) -> anyhow::Result<()> {
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Ptr(sptr0)],
+            spaces: vec![Subject::Ptr(sptr0)],
             to: Some(addr1.clone()),
             data: None,
         })],
@@ -135,7 +135,7 @@ async fn it_should_create_sptrs(rig: &TestRig) -> anyhow::Result<()> {
         .expect("valid addr1")
         .script_pubkey();
 
-    let ptr_after_xfer = rig.spaced.client.get_ptr(sptr0).await?
+    let ptr_after_xfer = rig.spaced.client.get_ptr(Subject::Ptr(sptr0)).await?
         .expect("ptr must still resolve after transfer");
     let bound_spk_after = ptr_after_xfer.ptrout.script_pubkey.clone();
 
@@ -153,7 +153,7 @@ async fn it_should_create_sptrs(rig: &TestRig) -> anyhow::Result<()> {
 
     mine_and_sync(rig, 1).await?;
 
-    let ptr_after_dup = rig.spaced.client.get_ptr(sptr0).await?
+    let ptr_after_dup = rig.spaced.client.get_ptr(Subject::Ptr(sptr0)).await?
         .expect("ptr must still resolve after duplicate");
     let bound_spk_final = ptr_after_dup.ptrout.script_pubkey.clone();
 
@@ -351,9 +351,9 @@ async fn it_should_handle_multiple_commitments(rig: &TestRig) -> anyhow::Result<
     println!("Space 2: {} -> SPTR: {}", space2_name, sptr2);
 
     // Verify delegations match delegator
-    let delegator1 = rig.spaced.client.get_delegator(sptr1).await?
+    let delegator1 = rig.spaced.client.get_delegator(Subject::Ptr(sptr1)).await?
         .expect("sptr1 delegator should exist");
-    let delegator2 = rig.spaced.client.get_delegator(sptr2).await?
+    let delegator2 = rig.spaced.client.get_delegator(Subject::Ptr(sptr2)).await?
         .expect("sptr2 delegator should exist");
 
     assert_eq!(delegator1.to_string(), space1_name.to_string(), "space 1 delegators dont match");
@@ -567,7 +567,7 @@ async fn it_should_reject_duplicate_sptr_delegations(rig: &TestRig) -> anyhow::R
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(space1_name.clone())],
+            spaces: vec![Subject::Space(space1_name.clone())],
             to: Some(common_addr.clone()),
             data: None,
         })],
@@ -577,7 +577,7 @@ async fn it_should_reject_duplicate_sptr_delegations(rig: &TestRig) -> anyhow::R
     mine_and_sync(rig, 1).await?;
 
     // Verify the reverse mapping: SPTR -> space1
-    let delegator1 = rig.spaced.client.get_delegator(common_sptr).await?
+    let delegator1 = rig.spaced.client.get_delegator(Subject::Ptr(common_sptr)).await?
         .expect("common SPTR should have delegator");
     assert_eq!(delegator1, space1_name, "common SPTR should point to space1");
 
@@ -590,7 +590,7 @@ async fn it_should_reject_duplicate_sptr_delegations(rig: &TestRig) -> anyhow::R
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(space2_name.clone())],
+            spaces: vec![Subject::Space(space2_name.clone())],
             to: Some(common_addr.clone()),
             data: None,
         })],
@@ -601,7 +601,7 @@ async fn it_should_reject_duplicate_sptr_delegations(rig: &TestRig) -> anyhow::R
 
     // Key test: Verify the reverse mapping was NOT overwritten
     // The SPTR should still point to space1, not space2
-    let delegator_after = rig.spaced.client.get_delegator(common_sptr).await?
+    let delegator_after = rig.spaced.client.get_delegator(Subject::Ptr(common_sptr)).await?
         .expect("common SPTR should still have delegator");
     assert_eq!(delegator_after, space1_name,
         "CRITICAL: common SPTR should still point to space1 (not overwritten by space2)");
@@ -619,7 +619,7 @@ async fn it_should_reject_duplicate_sptr_delegations(rig: &TestRig) -> anyhow::R
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(space1_name.clone())],
+            spaces: vec![Subject::Space(space1_name.clone())],
             to: Some(new_addr),
             data: None,
         })],
@@ -629,7 +629,7 @@ async fn it_should_reject_duplicate_sptr_delegations(rig: &TestRig) -> anyhow::R
     mine_and_sync(rig, 1).await?;
 
     // Verify common_sptr is now free (reverse mapping removed)
-    let delegator_freed = rig.spaced.client.get_delegator(common_sptr).await?;
+    let delegator_freed = rig.spaced.client.get_delegator(Subject::Ptr(common_sptr)).await?;
     assert_eq!(delegator_freed, None, "common SPTR should be free (no reverse mapping) after space1 moved");
 
     println!("✓ SPTR freed - reverse mapping removed");
@@ -640,7 +640,7 @@ async fn it_should_reject_duplicate_sptr_delegations(rig: &TestRig) -> anyhow::R
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(space2_name.clone())],
+            spaces: vec![Subject::Space(space2_name.clone())],
             to: Some(common_addr),
             data: None,
         })],
@@ -650,7 +650,7 @@ async fn it_should_reject_duplicate_sptr_delegations(rig: &TestRig) -> anyhow::R
     mine_and_sync(rig, 1).await?;
 
     // Verify space2 now owns the reverse mapping
-    let delegator2_retry = rig.spaced.client.get_delegator(common_sptr).await?
+    let delegator2_retry = rig.spaced.client.get_delegator(Subject::Ptr(common_sptr)).await?
         .expect("common SPTR should have delegator");
     assert_eq!(delegator2_retry, space2_name,
         "common SPTR should now point to space2 (reverse mapping updated)");
@@ -691,7 +691,7 @@ async fn it_should_restore_delegation_when_transferring_back(rig: &TestRig) -> a
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(space_name.clone())],
+            spaces: vec![Subject::Space(space_name.clone())],
             to: Some(original_addr.clone()),
             data: None,
         })],
@@ -701,7 +701,7 @@ async fn it_should_restore_delegation_when_transferring_back(rig: &TestRig) -> a
     mine_and_sync(rig, 1).await?;
 
     // Verify initial delegation is established
-    let initial_delegator = rig.spaced.client.get_delegator(original_sptr).await?
+    let initial_delegator = rig.spaced.client.get_delegator(Subject::Ptr(original_sptr)).await?
         .expect("Original SPTR should have delegation after setup");
     assert_eq!(initial_delegator, space_name);
     println!("✓ Initial delegation established: {} -> {}", original_sptr, space_name);
@@ -720,7 +720,7 @@ async fn it_should_restore_delegation_when_transferring_back(rig: &TestRig) -> a
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(space_name.clone())],
+            spaces: vec![Subject::Space(space_name.clone())],
             to: Some(new_addr.clone()),
             data: None,
         })],
@@ -730,13 +730,13 @@ async fn it_should_restore_delegation_when_transferring_back(rig: &TestRig) -> a
     mine_and_sync(rig, 1).await?;
 
     // Verify: original SPTR should have NO delegation now
-    let delegator_after_transfer1 = rig.spaced.client.get_delegator(original_sptr).await?;
+    let delegator_after_transfer1 = rig.spaced.client.get_delegator(Subject::Ptr(original_sptr)).await?;
     assert_eq!(delegator_after_transfer1, None,
         "Original SPTR should have no delegation after space was transferred away");
     println!("✓ Original SPTR delegation revoked: {:?}", delegator_after_transfer1);
 
     // Verify: new SPTR should have the delegation
-    let delegator_new = rig.spaced.client.get_delegator(new_sptr).await?
+    let delegator_new = rig.spaced.client.get_delegator(Subject::Ptr(new_sptr)).await?
         .expect("New SPTR should have delegation");
     assert_eq!(delegator_new, space_name,
         "New SPTR should point to the space");
@@ -750,7 +750,7 @@ async fn it_should_restore_delegation_when_transferring_back(rig: &TestRig) -> a
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Space(space_name.clone())],
+            spaces: vec![Subject::Space(space_name.clone())],
             to: Some(original_addr.clone()),
             data: None,
         })],
@@ -760,7 +760,7 @@ async fn it_should_restore_delegation_when_transferring_back(rig: &TestRig) -> a
     mine_and_sync(rig, 1).await?;
 
     // KEY TEST: Original SPTR should have delegation RESTORED
-    let delegator_restored = rig.spaced.client.get_delegator(original_sptr).await?;
+    let delegator_restored = rig.spaced.client.get_delegator(Subject::Ptr(original_sptr)).await?;
     println!("Delegation after transfer back: {:?}", delegator_restored);
 
     assert!(delegator_restored.is_some(),
@@ -771,7 +771,7 @@ async fn it_should_restore_delegation_when_transferring_back(rig: &TestRig) -> a
     println!("✓ Original SPTR delegation RESTORED: {} -> {}", original_sptr, space_name);
 
     // Verify: new SPTR should have NO delegation now
-    let delegator_new_after = rig.spaced.client.get_delegator(new_sptr).await?;
+    let delegator_new_after = rig.spaced.client.get_delegator(Subject::Ptr(new_sptr)).await?;
     assert_eq!(delegator_new_after, None,
         "New SPTR should have no delegation after space was transferred back");
     println!("✓ New SPTR delegation revoked");
@@ -807,9 +807,9 @@ async fn it_should_set_and_persist_ptr_data(rig: &TestRig) -> anyhow::Result<()>
     println!("SPTR created: {}", sptr);
 
     // Verify PTR exists with no data
-    let ptr_initial = rig.spaced.client.get_ptr(sptr).await?
+    let ptr_initial = rig.spaced.client.get_ptr(Subject::Ptr(sptr)).await?
         .expect("ptr should exist");
-    assert_eq!(ptr_initial.ptrout.sptr.as_ref().unwrap().data, None, "PTR should have no data initially");
+    assert_eq!(ptr_initial.ptrout.sptr.data, None, "PTR should have no data initially");
 
     // Test 2: Set data on the PTR
     println!("\nTest 2: Set data on PTR");
@@ -818,7 +818,7 @@ async fn it_should_set_and_persist_ptr_data(rig: &TestRig) -> anyhow::Result<()>
         rig,
         ALICE,
         vec![RpcWalletRequest::SetPtrData(SetPtrDataParams {
-            sptr,
+            subject: Subject::Ptr(sptr),
             data: test_data.clone(),
         })],
         false,
@@ -828,9 +828,9 @@ async fn it_should_set_and_persist_ptr_data(rig: &TestRig) -> anyhow::Result<()>
 
     use spaces_protocol::Bytes;
     // Verify data was set
-    let ptr_with_data = rig.spaced.client.get_ptr(sptr).await?
+    let ptr_with_data = rig.spaced.client.get_ptr(Subject::Ptr(sptr)).await?
         .expect("ptr should exist");
-    assert_eq!(ptr_with_data.ptrout.sptr.as_ref().unwrap().data, Some(Bytes::new(test_data.clone())), "PTR data should be set");
+    assert_eq!(ptr_with_data.ptrout.sptr.data, Some(Bytes::new(test_data.clone())), "PTR data should be set");
     println!("✓ PTR data set successfully: {:?}", String::from_utf8_lossy(&test_data));
 
     // Test 3: Transfer PTR without data - data should persist
@@ -840,7 +840,7 @@ async fn it_should_set_and_persist_ptr_data(rig: &TestRig) -> anyhow::Result<()>
         rig,
         ALICE,
         vec![RpcWalletRequest::Transfer(TransferSpacesParams {
-            spaces: vec![SpaceOrPtr::Ptr(sptr)],
+            spaces: vec![Subject::Ptr(sptr)],
             to: Some(bob_addr.clone()),
             data: None,
         })],
@@ -849,9 +849,9 @@ async fn it_should_set_and_persist_ptr_data(rig: &TestRig) -> anyhow::Result<()>
     assert!(wallet_res_err(&transfer).is_ok(), "Transfer PTR should succeed");
     mine_and_sync(rig, 1).await?;
 
-    let ptr_after_transfer = rig.spaced.client.get_ptr(sptr).await?
+    let ptr_after_transfer = rig.spaced.client.get_ptr(Subject::Ptr(sptr)).await?
         .expect("ptr should exist after transfer");
-    assert_eq!(ptr_after_transfer.ptrout.sptr.as_ref().unwrap().data, Some(Bytes::new(test_data.clone())),
+    assert_eq!(ptr_after_transfer.ptrout.sptr.data, Some(Bytes::new(test_data.clone())),
         "PTR data should persist after transfer without new data");
     println!("✓ PTR data persisted after transfer");
 
@@ -862,7 +862,7 @@ async fn it_should_set_and_persist_ptr_data(rig: &TestRig) -> anyhow::Result<()>
         rig,
         BOB,
         vec![RpcWalletRequest::SetPtrData(SetPtrDataParams {
-            sptr,
+            subject: Subject::Ptr(sptr),
             data: new_data.clone(),
         })],
         false,
@@ -870,9 +870,9 @@ async fn it_should_set_and_persist_ptr_data(rig: &TestRig) -> anyhow::Result<()>
     assert!(wallet_res_err(&update_data).is_ok(), "SetPtrData should succeed");
     mine_and_sync(rig, 1).await?;
 
-    let ptr_updated = rig.spaced.client.get_ptr(sptr).await?
+    let ptr_updated = rig.spaced.client.get_ptr(Subject::Ptr(sptr)).await?
         .expect("ptr should exist");
-    assert_eq!(ptr_updated.ptrout.sptr.as_ref().unwrap().data, Some(Bytes::new(new_data.clone())), "PTR data should be updated");
+    assert_eq!(ptr_updated.ptrout.sptr.data, Some(Bytes::new(new_data.clone())), "PTR data should be updated");
     println!("✓ PTR data updated successfully: {:?}", String::from_utf8_lossy(&new_data));
 
     // Test 5: Set empty data
@@ -882,7 +882,7 @@ async fn it_should_set_and_persist_ptr_data(rig: &TestRig) -> anyhow::Result<()>
         rig,
         BOB,
         vec![RpcWalletRequest::SetPtrData(SetPtrDataParams {
-            sptr,
+            subject: Subject::Ptr(sptr),
             data: empty_data.clone(),
         })],
         false,
@@ -890,9 +890,9 @@ async fn it_should_set_and_persist_ptr_data(rig: &TestRig) -> anyhow::Result<()>
     assert!(wallet_res_err(&set_empty).is_ok(), "SetPtrData with empty data should succeed");
     mine_and_sync(rig, 1).await?;
 
-    let ptr_empty = rig.spaced.client.get_ptr(sptr).await?
+    let ptr_empty = rig.spaced.client.get_ptr(Subject::Ptr(sptr)).await?
         .expect("ptr should exist");
-    assert_eq!(ptr_empty.ptrout.sptr.as_ref().unwrap().data, Some(Bytes::new(empty_data)), "PTR data should be set to empty");
+    assert_eq!(ptr_empty.ptrout.sptr.data, Some(Bytes::new(empty_data)), "PTR data should be set to empty");
     println!("✓ PTR data set to empty successfully");
 
     Ok(())
@@ -1095,21 +1095,21 @@ async fn it_should_transfer_ptr_with_n_to_n_rule(rig: &TestRig) -> anyhow::Resul
         mine_and_sync(rig, 1).await?;
 
         let sptr = Sptr::from_spk::<Sha256>(addr0_spk.clone());
-        let ptr_before = rig.spaced.client.get_ptr(sptr).await?.expect("ptr must exist");
+        let ptr_before = rig.spaced.client.get_ptr(Subject::Ptr(sptr)).await?.expect("ptr must exist");
         let value_before = ptr_before.ptrout.value;
 
         // Transfer to addr1 with SAME value (should use n→n rule)
         let addr1 = rig.spaced.client.wallet_get_new_address(BOB, AddressKind::Space).await?;
         wallet_do(rig, ALICE, vec![
             RpcWalletRequest::Transfer(TransferSpacesParams {
-                spaces: vec![SpaceOrPtr::Ptr(sptr)],
+                spaces: vec![Subject::Ptr(sptr)],
                 to: Some(addr1.clone()),
                 data: None,
             })
         ], false).await?;
         mine_and_sync(rig, 1).await?;
 
-        let ptr_after = rig.spaced.client.get_ptr(sptr).await?.expect("ptr must still exist");
+        let ptr_after = rig.spaced.client.get_ptr(Subject::Ptr(sptr)).await?.expect("ptr must still exist");
         let spk1 = SpaceAddress::from_str(&addr1)?.script_pubkey();
 
         assert_eq!(ptr_after.ptrout.script_pubkey, spk1, "PTR should transfer to new address");
@@ -1141,20 +1141,20 @@ async fn it_should_transfer_ptr_with_n_to_n_rule(rig: &TestRig) -> anyhow::Resul
 
         wallet_do(rig, ALICE, vec![
             RpcWalletRequest::Transfer(TransferSpacesParams {
-                spaces: vec![SpaceOrPtr::Ptr(sptr_a)],
+                spaces: vec![Subject::Ptr(sptr_a)],
                 to: Some(dest_a.clone()),
                 data: None,
             }),
             RpcWalletRequest::Transfer(TransferSpacesParams {
-                spaces: vec![SpaceOrPtr::Ptr(sptr_b)],
+                spaces: vec![Subject::Ptr(sptr_b)],
                 to: Some(dest_b.clone()),
                 data: None,
             }),
         ], false).await?;
         mine_and_sync(rig, 1).await?;
 
-        let ptr_a_after = rig.spaced.client.get_ptr(sptr_a).await?.expect("ptr_a must exist");
-        let ptr_b_after = rig.spaced.client.get_ptr(sptr_b).await?.expect("ptr_b must exist");
+        let ptr_a_after = rig.spaced.client.get_ptr(Subject::Ptr(sptr_a)).await?.expect("ptr_a must exist");
+        let ptr_b_after = rig.spaced.client.get_ptr(Subject::Ptr(sptr_b)).await?.expect("ptr_b must exist");
         let spk_dest_a = SpaceAddress::from_str(&dest_a)?.script_pubkey();
         let spk_dest_b = SpaceAddress::from_str(&dest_b)?.script_pubkey();
 
@@ -1179,7 +1179,7 @@ async fn it_should_transfer_ptr_with_n_to_n_rule(rig: &TestRig) -> anyhow::Resul
 
         let sptr = rig.spaced.client.get_delegation(space_name.clone()).await?
             .expect("delegation should exist");
-        let ptr_before_commit = rig.spaced.client.get_ptr(sptr).await?.expect("ptr must exist");
+        let ptr_before_commit = rig.spaced.client.get_ptr(Subject::Ptr(sptr)).await?.expect("ptr must exist");
         let value_before = ptr_before_commit.ptrout.value;
         let spk_before = ptr_before_commit.ptrout.script_pubkey.clone();
 
@@ -1192,7 +1192,7 @@ async fn it_should_transfer_ptr_with_n_to_n_rule(rig: &TestRig) -> anyhow::Resul
         ], false).await?;
         mine_and_sync(rig, 1).await?;
 
-        let ptr_after_commit = rig.spaced.client.get_ptr(sptr).await?.expect("ptr must exist after commit");
+        let ptr_after_commit = rig.spaced.client.get_ptr(Subject::Ptr(sptr)).await?.expect("ptr must exist after commit");
 
         assert_eq!(ptr_after_commit.ptrout.value, value_before, "Commitment should preserve PTR value (n→n)");
         assert_eq!(ptr_after_commit.ptrout.script_pubkey, spk_before, "Commitment should keep same address");

--- a/protocol/src/script.rs
+++ b/protocol/src/script.rs
@@ -96,6 +96,9 @@ pub fn load_open_context<T: SpacesSource, H: KeyHasher>(
     if name.is_reserved() {
         return Ok(Some(Err(OpenError::ReservedName)));
     }
+    if name.is_numeric() {
+        return Ok(Some(Err(OpenError::MalformedName)));
+    }
 
     let ctx = {
         let spacehash = SpaceKey::from(H::hash(name.as_ref()));
@@ -123,8 +126,8 @@ fn find_open(script: &Script) -> Option<OpenResult<SLabelRef<'_>>> {
             Instruction::Op(_) => continue,
             Instruction::PushBytes(push_bytes) => {
                 let mut bytes = push_bytes.as_bytes();
-                // Starts with our prefix + at least 1 additional op code byte
-                if bytes.len() < OPEN_MAGIC.len() || !bytes.starts_with(OPEN_MAGIC) {
+                // Starts with our prefix + at least 1 additional byte
+                if bytes.len() <= OPEN_MAGIC.len() || !bytes.starts_with(OPEN_MAGIC) {
                     continue;
                 }
                 bytes = &bytes[OPEN_MAGIC.len()..];

--- a/protocol/src/slabel.rs
+++ b/protocol/src/slabel.rs
@@ -160,6 +160,27 @@ impl<'a> TryFrom<&'a [u8]> for SLabelRef<'a> {
             return Err(Error::Name(NameErrorKind::EOF));
         }
         let label = &value[..=len];
+
+        // Numeric label: #<digits>-<digits>
+        if label[1] == b'#' {
+            let content = &label[2..];
+            let dash_pos = content.iter().position(|&c| c == b'-')
+                .filter(|&p| p > 0)
+                .ok_or(Error::Name(NameErrorKind::InvalidCharacter))?;
+
+            let (before, after) = content.split_at(dash_pos);
+            let after = &after[1..]; // skip the dash
+
+            if after.is_empty()
+                || !before.iter().all(|c| c.is_ascii_digit())
+                || !after.iter().all(|c| c.is_ascii_digit())
+            {
+                return Err(Error::Name(NameErrorKind::InvalidCharacter));
+            }
+
+            return Ok(SLabelRef(label));
+        }
+
         let mut verify_range = &label[1..];
         if verify_range.starts_with(PUNYCODE_PREFIX) && len > PUNYCODE_PREFIX.len() {
             verify_range = &verify_range[PUNYCODE_PREFIX.len()..]
@@ -221,18 +242,24 @@ impl TryFrom<&str> for SLabel {
     type Error = Error;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        if !value.starts_with('@') {
-            return Err(Error::Name(NameErrorKind::NotCanonical));
+        if value.starts_with('#') {
+            return Self::from_str_unprefixed(value);
         }
-        let label = &value[1..];
-        Self::from_str_unprefixed(label)
+        if value.starts_with('@') {
+            return Self::from_str_unprefixed(&value[1..]);
+        }
+        Err(Error::Name(NameErrorKind::NotCanonical))
     }
 }
 
 impl Display for SLabel {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let label_str = self.as_str_unprefixed().map_err(|_| core::fmt::Error)?;
-        write!(f, "@{}", label_str)
+        if self.is_numeric() {
+            write!(f, "{}", label_str)
+        } else {
+            write!(f, "@{}", label_str)
+        }
     }
 }
 
@@ -247,6 +274,10 @@ impl SLabel {
         SLabelRef(&self.0)
     }
 
+    pub fn is_numeric(&self) -> bool {
+        self.0[0] > 0 && self.0[1] == b'#'
+    }
+
     pub fn is_reserved(&self) -> bool {
         self.as_name_ref().is_reserved()
     }
@@ -257,6 +288,10 @@ impl SLabelRef<'_> {
         let mut owned = SLabel([0; MAX_LABEL_LEN + 1]);
         owned.0[..self.0.len()].copy_from_slice(self.0);
         owned
+    }
+
+    pub fn is_numeric(&self) -> bool {
+        self.0[0] > 0 && self.0.get(1) == Some(&b'#')
     }
 
     pub fn is_reserved(&self) -> bool {
@@ -465,5 +500,94 @@ mod tests {
         assert!(SLabel::try_from("@xn-").is_err());
         assert!(SLabel::try_from("@xn--").is_err());
         assert!(SLabel::try_from("@xxn--test").is_err());
+    }
+
+    #[test]
+    fn test_numeric_valid() {
+        let label = SLabel::try_from("#800000-3").unwrap();
+        assert_eq!(label.to_string(), "#800000-3");
+        assert!(label.is_numeric());
+
+        let label = SLabel::try_from("#0-0").unwrap();
+        assert_eq!(label.to_string(), "#0-0");
+        assert!(label.is_numeric());
+
+        let label = SLabel::try_from("#1-1").unwrap();
+        assert_eq!(label.to_string(), "#1-1");
+
+        // Large values
+        let label = SLabel::try_from("#4294967295-65535").unwrap();
+        assert_eq!(label.to_string(), "#4294967295-65535");
+    }
+
+    #[test]
+    fn test_numeric_invalid() {
+        // Just "#" with nothing after
+        assert!(SLabel::try_from("#").is_err(), "bare # should be invalid");
+
+        // Missing separator
+        assert!(SLabel::try_from("#123").is_err(), "missing dash");
+
+        // No digits before dash
+        assert!(SLabel::try_from("#-3").is_err(), "no digits before dash");
+
+        // No digits after dash
+        assert!(SLabel::try_from("#3-").is_err(), "no digits after dash");
+
+        // Non-digit characters
+        assert!(SLabel::try_from("#abc-3").is_err(), "letters before dash");
+        assert!(SLabel::try_from("#3-abc").is_err(), "letters after dash");
+
+        // Multiple dashes
+        assert!(SLabel::try_from("#3-4-5").is_err(), "multiple dashes");
+
+        // Spaces
+        assert!(SLabel::try_from("# 3-4").is_err(), "space in numeric");
+
+        // Dash only content
+        assert!(SLabel::try_from("#-").is_err(), "just dash after #");
+    }
+
+    #[test]
+    fn test_numeric_is_numeric() {
+        let named = SLabel::try_from("@example").unwrap();
+        assert!(!named.is_numeric());
+
+        let numeric = SLabel::try_from("#100-5").unwrap();
+        assert!(numeric.is_numeric());
+    }
+
+    #[test]
+    fn test_numeric_display_no_at_prefix() {
+        let label = SLabel::try_from("#100-5").unwrap();
+        // Should display as "#100-5" NOT "@#100-5"
+        assert_eq!(format!("{}", label), "#100-5");
+    }
+
+    #[test]
+    fn test_numeric_fromstr_roundtrip() {
+        let original = "#999-42";
+        let label = SLabel::from_str(original).unwrap();
+        assert_eq!(label.to_string(), original);
+    }
+
+    #[test]
+    fn test_numeric_raw_bytes() {
+        let label = SLabel::try_from("#1-2").unwrap();
+        // Content stored is "#1-2" (4 bytes), length byte = 4
+        let raw = label.as_ref();
+        assert_eq!(raw[0], 4); // length
+        assert_eq!(&raw[1..], b"#1-2");
+    }
+
+    #[test]
+    fn test_numeric_slabelref() {
+        // Build raw bytes: length + "#1-2"
+        let bytes = b"\x04#1-2";
+        let label_ref = SLabelRef::try_from(bytes.as_slice()).unwrap();
+        assert!(label_ref.is_numeric());
+        let owned = label_ref.to_owned();
+        assert!(owned.is_numeric());
+        assert_eq!(owned.to_string(), "#1-2");
     }
 }

--- a/ptr/src/lib.rs
+++ b/ptr/src/lib.rs
@@ -104,9 +104,8 @@ pub struct FullPtrOut {
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct PtrOut {
     pub n: usize,
-    /// Any handle associated with this output
     #[cfg_attr(feature = "serde", serde(flatten))]
-    pub sptr: Option<Ptr>,
+    pub sptr: Ptr,
     /// The value of the output, in satoshis.
     #[cfg_attr(
         feature = "borsh",
@@ -253,6 +252,7 @@ pub struct ChainProofRequest {
 #[derive(Clone, Copy)]
 pub enum PtrKeyKind {
     Sptr(Sptr),
+    Numeric(SNumeric),
     Commitment(CommitmentKey),
     Registry(RegistryKey),
 }
@@ -408,51 +408,48 @@ impl TxContext {
             let ptrout = src.get_ptrout(&input.previous_output)?;
 
             if let Some(ptrout) = ptrout {
-                let delegate = match &ptrout.sptr {
-                    Some(sptr) => {
-                        let rsk = RegistrySptrKey::from_sptr::<H>(sptr.id);
+                let delegate = {
+                    let rsk = RegistrySptrKey::from_sptr::<H>(ptrout.sptr.id);
 
-                        match src.get_delegator(&rsk)? {
-                            Some(slabel) => {
-                                let registry_key = RegistryKey::from_slabel::<H>(&slabel);
-                                let tip_root = src.get_commitments_tip(&registry_key)?;
-                                let tip = match tip_root {
-                                    Some(root) => {
-                                        let ck = CommitmentKey::new::<H>(&slabel, root);
-                                        src.get_commitment(&ck)?
-                                    }
-                                    None => None,
-                                };
+                    match src.get_delegator(&rsk)? {
+                        Some(slabel) => {
+                            let registry_key = RegistryKey::from_slabel::<H>(&slabel);
+                            let tip_root = src.get_commitments_tip(&registry_key)?;
+                            let tip = match tip_root {
+                                Some(root) => {
+                                    let ck = CommitmentKey::new::<H>(&slabel, root);
+                                    src.get_commitment(&ck)?
+                                }
+                                None => None,
+                            };
 
-                                // Determine pending and finalized tips
-                                let (pending_tip, finalized_tip) = match tip {
-                                    Some(t) if t.is_finalized(height) => {
-                                        (None, Some(t))
-                                    }
-                                    Some(t) => {
-                                        // Tip is pending, check for previous finalized commitment
-                                        let finalized = match t.prev_root {
-                                            Some(prev_root) => {
-                                                let ck = CommitmentKey::new::<H>(&slabel, prev_root);
-                                                src.get_commitment(&ck)?
-                                            }
-                                            None => None,
-                                        };
-                                        (Some(t), finalized)
-                                    }
-                                    None => (None, None),
-                                };
+                            // Determine pending and finalized tips
+                            let (pending_tip, finalized_tip) = match tip {
+                                Some(t) if t.is_finalized(height) => {
+                                    (None, Some(t))
+                                }
+                                Some(t) => {
+                                    // Tip is pending, check for previous finalized commitment
+                                    let finalized = match t.prev_root {
+                                        Some(prev_root) => {
+                                            let ck = CommitmentKey::new::<H>(&slabel, prev_root);
+                                            src.get_commitment(&ck)?
+                                        }
+                                        None => None,
+                                    };
+                                    (Some(t), finalized)
+                                }
+                                None => (None, None),
+                            };
 
-                                Some(DelegateContext {
-                                    space: slabel,
-                                    pending_tip,
-                                    finalized_tip,
-                                })
-                            }
-                            None => None,
+                            Some(DelegateContext {
+                                space: slabel,
+                                pending_tip,
+                                finalized_tip,
+                            })
                         }
+                        None => None,
                     }
-                    None => None,
                 };
 
                 inputs.push(Stxo {
@@ -645,12 +642,12 @@ impl Validator {
 
             changeset.creates.push(PtrOut {
                 n,
-                sptr: Some(Ptr {
+                sptr: Ptr {
                     id: Sptr::from_spk::<H>(output.script_pubkey.clone()),
                     numeric: SNumeric::new(height, tx_pos),
                     data: data_op.clone(),
                     last_update: height,
-                }),
+                },
                 value: output.value,
                 script_pubkey: output.script_pubkey.clone(),
             });
@@ -669,10 +666,7 @@ impl Validator {
         height: u32,
         data: &Option<Bytes>,
     ) {
-        let mut ptr = match ptrout.sptr {
-            None => return,
-            Some(ptr) => ptr,
-        };
+        let mut ptr = ptrout.sptr;
         // if a corresponding output at the same index has the same value,
         // that output becomes the PTR
         let mut output_index = input_index;
@@ -707,7 +701,7 @@ impl Validator {
         ptrout.n = output_index;
         ptrout.value = output.value;
         ptrout.script_pubkey = output.script_pubkey.clone();
-        ptrout.sptr = Some(ptr);
+        ptrout.sptr = ptr;
         changeset.creates.push(ptrout);
     }
 }

--- a/ptr/src/lib.rs
+++ b/ptr/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "std")]
 pub mod sptr;
 pub mod constants;
+pub mod snumeric;
 
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -8,6 +9,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use spaces_protocol::constants::ChainAnchor;
+use spaces_protocol::script::find_op_set_data;
 use bitcoin::{Amount, OutPoint, ScriptBuf, Transaction, TxOut, Txid};
 use bitcoin::absolute::LockTime;
 use bitcoin::opcodes::all::{OP_PUSHNUM_2, OP_RETURN};
@@ -16,8 +19,8 @@ use spaces_protocol::hasher::{KeyHasher, KeyHash, Hash};
 use spaces_protocol::slabel::SLabel;
 use spaces_protocol::{Bytes, SpaceOut};
 use crate::constants::COMMITMENT_FINALITY_INTERVAL;
-use crate::sptr::{Sptr};
-
+use crate::snumeric::SNumeric;
+use crate::sptr::Sptr;
 
 pub trait PtrSource {
     fn get_ptr_outpoint(&mut self, sptr: &Sptr) -> spaces_protocol::errors::Result<Option<OutPoint>>;
@@ -29,6 +32,8 @@ pub trait PtrSource {
     fn get_delegator(&mut self, sptr: &RegistrySptrKey) -> spaces_protocol::errors::Result<Option<SLabel>>;
 
     fn get_ptrout(&mut self, outpoint: &OutPoint) -> spaces_protocol::errors::Result<Option<PtrOut>>;
+
+    fn get_numeric(&mut self, key: &NumericKey) -> spaces_protocol::errors::Result<Option<Sptr>>;
 }
 
 #[derive(Debug, Clone)]
@@ -127,6 +132,7 @@ pub struct PtrOut {
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct Ptr {
     pub id: Sptr,
+    pub numeric: SNumeric,
     pub data: Option<Bytes>,
     pub last_update: u32,
 }
@@ -168,6 +174,7 @@ pub enum KeyKind {
     Registry = 0x03,
     RegistrySptr = 0x04,
     PtrOutpoint = 0x05,
+    SNumeric = 0x06,
 }
 
 impl KeyKind {
@@ -202,6 +209,10 @@ pub struct CommitmentKey([u8; 32]);
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct PtrOutpointKey([u8; 32]);
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct NumericKey([u8; 32]);
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -250,6 +261,7 @@ impl KeyHash for RegistryKey {}
 impl KeyHash for RegistrySptrKey {}
 impl KeyHash for CommitmentKey {}
 impl KeyHash for PtrOutpointKey {}
+impl KeyHash for NumericKey {}
 
 impl Commitment {
     pub fn is_finalized(&self, height: u32) -> bool {
@@ -291,6 +303,12 @@ impl From<PtrOutpointKey> for Hash {
     }
 }
 
+impl From<NumericKey> for Hash {
+    fn from(value: NumericKey) -> Self {
+        value.0
+    }
+}
+
 impl PtrOutpointKey {
     pub fn from_outpoint<H: KeyHasher>(outpoint: OutPoint) -> Self {
         let mut buffer = [0u8; 36];
@@ -319,6 +337,15 @@ impl RegistryKey {
 impl RegistrySptrKey {
     pub fn from_sptr<H: KeyHasher>(sptr: Sptr) -> Self {
         RegistrySptrKey(ns_hash::<H>(KeyKind::RegistrySptr, sptr.to_bytes()))
+    }
+}
+
+impl NumericKey {
+    pub fn from_numeric<H: KeyHasher>(numeric: &SNumeric) -> Self {
+        let mut buf = [0u8; 6];
+        buf[..4].copy_from_slice(&numeric.block().to_le_bytes());
+        buf[4..].copy_from_slice(&numeric.tx_pos().to_le_bytes());
+        Self(ns_hash::<H>(KeyKind::SNumeric, H::hash(&buf)))
     }
 }
 
@@ -479,6 +506,7 @@ impl Validator {
     pub fn process<H: KeyHasher>(
         &self, height: u32,
         tx: &Transaction,
+        tx_pos: u16,
         mut ctx: TxContext,
         spent_space_utxos: Vec<SpaceOut>,
         new_space_utxos: Vec<SpaceOut>,
@@ -619,6 +647,7 @@ impl Validator {
                 n,
                 sptr: Some(Ptr {
                     id: Sptr::from_spk::<H>(output.script_pubkey.clone()),
+                    numeric: SNumeric::new(height, tx_pos),
                     data: data_op.clone(),
                     last_update: height,
                 }),
@@ -880,6 +909,5 @@ mod hash_key_serde {
     impl_hash_key_serde!(RegistryKey);
     impl_hash_key_serde!(CommitmentKey);
 }
-use spaces_protocol::constants::ChainAnchor;
-use spaces_protocol::script::find_op_set_data;
+
 

--- a/ptr/src/snumeric.rs
+++ b/ptr/src/snumeric.rs
@@ -1,0 +1,190 @@
+use core::{fmt, str::FromStr};
+use spaces_protocol::slabel::SLabel;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SNumeric {
+    block: u32,
+    tx_pos: u16,
+}
+
+impl SNumeric {
+    pub fn new(block: u32, tx_pos: u16) -> Self {
+        Self { block, tx_pos }
+    }
+
+    #[inline]
+    pub fn block(&self) -> u32 { self.block }
+
+    #[inline]
+    pub fn tx_pos(&self) -> u16 { self.tx_pos }
+
+    pub fn to_slabel(&self) -> SLabel {
+        SLabel::from_str(&self.to_string()).expect("valid numeric label")
+    }
+}
+
+impl TryFrom<SLabel> for SNumeric {
+    type Error = SNumericParseError;
+
+    fn try_from(label: SLabel) -> Result<Self, Self::Error> {
+        let s = label.as_str_unprefixed().map_err(|_| SNumericParseError::MissingPrefix)?;
+        SNumeric::from_str(s)
+    }
+}
+
+#[derive(Debug)]
+pub enum SNumericParseError {
+    MissingPrefix,
+    MissingSeparator,
+    InvalidBlock(core::num::ParseIntError),
+    InvalidTxPos(core::num::ParseIntError),
+}
+
+impl fmt::Display for SNumericParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SNumericParseError::MissingPrefix => f.write_str("expected '#' prefix"),
+            SNumericParseError::MissingSeparator => f.write_str("expected '#<block>-<tx_pos>' format"),
+            SNumericParseError::InvalidBlock(e) => write!(f, "invalid block number: {e}"),
+            SNumericParseError::InvalidTxPos(e) => write!(f, "invalid tx position: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SNumericParseError {}
+
+impl fmt::Display for SNumeric {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "#{}-{}", self.block, self.tx_pos)
+    }
+}
+
+impl FromStr for SNumeric {
+    type Err = SNumericParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix('#').ok_or(SNumericParseError::MissingPrefix)?;
+        let (block_str, pos_str) = s.split_once('-').ok_or(SNumericParseError::MissingSeparator)?;
+        let block = block_str.parse::<u32>().map_err(SNumericParseError::InvalidBlock)?;
+        let tx_pos = pos_str.parse::<u16>().map_err(SNumericParseError::InvalidTxPos)?;
+        Ok(SNumeric { block, tx_pos })
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for SNumeric {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.to_string())
+        } else {
+            let mut buf = [0u8; 6];
+            buf[..4].copy_from_slice(&self.block.to_le_bytes());
+            buf[4..].copy_from_slice(&self.tx_pos.to_le_bytes());
+            serializer.serialize_bytes(&buf)
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for SNumeric {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            SNumeric::from_str(&s).map_err(serde::de::Error::custom)
+        } else {
+            let buf = <[u8; 6]>::deserialize(deserializer)?;
+            Ok(SNumeric {
+                block: u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]),
+                tx_pos: u16::from_le_bytes([buf[4], buf[5]]),
+            })
+        }
+    }
+}
+
+#[cfg(feature = "borsh")]
+mod borsh_impl {
+    use borsh::{io, BorshDeserialize, BorshSerialize};
+    use super::*;
+
+    impl BorshSerialize for SNumeric {
+        fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+            self.block.serialize(writer)?;
+            self.tx_pos.serialize(writer)
+        }
+    }
+
+    impl BorshDeserialize for SNumeric {
+        fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+            let block = u32::deserialize_reader(reader)?;
+            let tx_pos = u16::deserialize_reader(reader)?;
+            Ok(SNumeric { block, tx_pos })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let x = SNumeric::new(800_000, 3);
+        let s = x.to_string();
+        assert_eq!(s, "#800000-3");
+        let y: SNumeric = s.parse().unwrap();
+        assert_eq!(x, y);
+    }
+
+    #[test]
+    fn zero() {
+        let x = SNumeric::new(0, 0);
+        assert_eq!(x.to_string(), "#0-0");
+        assert_eq!("#0-0".parse::<SNumeric>().unwrap(), x);
+    }
+
+    #[test]
+    fn rejects_missing_prefix() {
+        let err = "800000-3".parse::<SNumeric>().unwrap_err();
+        matches!(err, SNumericParseError::MissingPrefix);
+    }
+
+    #[test]
+    fn rejects_missing_separator() {
+        let err = "#800000".parse::<SNumeric>().unwrap_err();
+        matches!(err, SNumericParseError::MissingSeparator);
+    }
+
+    #[test]
+    fn rejects_invalid_block() {
+        let err = "#abc-3".parse::<SNumeric>().unwrap_err();
+        matches!(err, SNumericParseError::InvalidBlock(_));
+    }
+
+    #[test]
+    fn rejects_invalid_tx_pos() {
+        let err = "#800000-abc".parse::<SNumeric>().unwrap_err();
+        matches!(err, SNumericParseError::InvalidTxPos(_));
+    }
+
+    #[test]
+    fn slabel_roundtrip() {
+        let x = SNumeric::new(800_000, 3);
+        let label = x.to_slabel();
+        assert_eq!(label.to_string(), "#800000-3");
+        assert!(label.is_numeric());
+        let y = SNumeric::try_from(label).unwrap();
+        assert_eq!(x, y);
+    }
+
+    #[test]
+    fn slabel_rejects_non_numeric() {
+        let label = SLabel::from_str("@example").unwrap();
+        assert!(SNumeric::try_from(label).is_err());
+    }
+}

--- a/ptr/src/sptr.rs
+++ b/ptr/src/sptr.rs
@@ -11,6 +11,7 @@ impl KeyHash for Sptr {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Sptr(pub(crate) [u8; 32]);
 
+
 impl Sptr {
     #[inline]
     pub fn as_slice(&self) -> &[u8] { &self.0 }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -46,7 +46,8 @@ use spaces_protocol::{
     slabel::SLabel,
     Covenant, FullSpaceOut, Space,
 };
-use spaces_ptr::{PtrSource, sptr::Sptr};
+use spaces_ptr::{NumericKey, PtrSource, sptr::Sptr};
+use spaces_ptr::snumeric::SNumeric;
 
 use crate::{
     address::SpaceAddress,
@@ -83,11 +84,44 @@ pub struct Balance {
     pub details: BalanceDetails,
 }
 
-/// Either a space name or an Sptr
+/// A space name, sptr, or numeric identifier
 #[derive(Debug, Clone)]
-pub enum SpaceOrSptr {
+pub enum Subject {
     Space(SLabel),
-    Sptr(Sptr),
+    Ptr(Sptr),
+    Numeric(SNumeric),
+}
+
+impl Serialize for Subject {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Subject::Space(label) => serializer.serialize_str(&label.to_string()),
+            Subject::Ptr(sptr) => serializer.serialize_str(&sptr.to_string()),
+            Subject::Numeric(num) => serializer.serialize_str(&num.to_string()),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Subject {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = <String as Deserialize>::deserialize(deserializer)?;
+        if s.starts_with("sptr1") {
+            Sptr::from_str(&s)
+                .map(Subject::Ptr)
+                .map_err(serde::de::Error::custom)
+        } else if s.starts_with('#') {
+            SNumeric::from_str(&s)
+                .map(Subject::Numeric)
+                .map_err(serde::de::Error::custom)
+        } else {
+            SLabel::from_str(&s)
+                .map(Subject::Space)
+                .map_err(serde::de::Error::custom)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -407,11 +441,11 @@ impl SpacesWallet {
     pub fn sign_event<H: KeyHasher, S: SpacesSource + PtrSource>(
         &mut self,
         src: &mut S,
-        space_or_sptr: SpaceOrSptr,
+        subject: Subject,
         mut event: NostrEvent,
     ) -> anyhow::Result<NostrEvent> {
-        let outpoint = match &space_or_sptr {
-            SpaceOrSptr::Space(label) => {
+        let outpoint = match &subject {
+            Subject::Space(label) => {
                 if event.space().is_some_and(|s| s != label.to_string()) {
                     return Err(anyhow::anyhow!("Space tag does not match specified space"));
                 }
@@ -419,8 +453,15 @@ impl SpacesWallet {
                 src.get_space_outpoint(&space_key)?
                     .ok_or_else(|| anyhow::anyhow!("Space not found"))?
             }
-            SpaceOrSptr::Sptr(sptr) => {
+            Subject::Ptr(sptr) => {
                 src.get_ptr_outpoint(sptr)?
+                    .ok_or_else(|| anyhow::anyhow!("Sptr not found"))?
+            }
+            Subject::Numeric(numeric) => {
+                let key = NumericKey::from_numeric::<H>(numeric);
+                let sptr = src.get_numeric(&key)?
+                    .ok_or_else(|| anyhow::anyhow!("Numeric '{}' not found", numeric))?;
+                src.get_ptr_outpoint(&sptr)?
                     .ok_or_else(|| anyhow::anyhow!("Sptr not found"))?
             }
         };
@@ -438,11 +479,11 @@ impl SpacesWallet {
 
     pub fn verify_event<H: KeyHasher, S: SpacesSource + PtrSource>(
         src: &mut S,
-        space_or_sptr: SpaceOrSptr,
+        subject: Subject,
         mut event: NostrEvent,
     ) -> anyhow::Result<NostrEvent> {
-        let script_pubkey = match &space_or_sptr {
-            SpaceOrSptr::Space(label) => {
+        let script_pubkey = match &subject {
+            Subject::Space(label) => {
                 if event.space().is_some_and(|s| s != label.to_string()) {
                     return Err(anyhow::anyhow!("Space tag does not match specified space"));
                 }
@@ -453,8 +494,18 @@ impl SpacesWallet {
                     .ok_or_else(|| anyhow::anyhow!("Space not found"))?;
                 spaceout.script_pubkey
             }
-            SpaceOrSptr::Sptr(sptr) => {
+            Subject::Ptr(sptr) => {
                 let outpoint = src.get_ptr_outpoint(sptr)?
+                    .ok_or_else(|| anyhow::anyhow!("Sptr not found"))?;
+                let ptrout = src.get_ptrout(&outpoint)?
+                    .ok_or_else(|| anyhow::anyhow!("Ptrout not found"))?;
+                ptrout.script_pubkey
+            }
+            Subject::Numeric(numeric) => {
+                let key = NumericKey::from_numeric::<H>(numeric);
+                let sptr = src.get_numeric(&key)?
+                    .ok_or_else(|| anyhow::anyhow!("Numeric '{}' not found", numeric))?;
+                let outpoint = src.get_ptr_outpoint(&sptr)?
                     .ok_or_else(|| anyhow::anyhow!("Sptr not found"))?;
                 let ptrout = src.get_ptrout(&outpoint)?
                     .ok_or_else(|| anyhow::anyhow!("Ptrout not found"))?;
@@ -493,19 +544,26 @@ impl SpacesWallet {
     pub fn sign_schnorr<H: KeyHasher, S: SpacesSource + PtrSource>(
         &mut self,
         src: &mut S,
-        space_or_sptr: SpaceOrSptr,
+        subject: Subject,
         message: &[u8],
     ) -> anyhow::Result<schnorr::Signature> {
         use bitcoin::hashes::{sha256, Hash, HashEngine};
 
-        let outpoint = match space_or_sptr {
-            SpaceOrSptr::Space(ref label) => {
+        let outpoint = match &subject {
+            Subject::Space(label) => {
                 let space_key = SpaceKey::from(H::hash(label.as_ref()));
                 src.get_space_outpoint(&space_key)?
                     .ok_or_else(|| anyhow::anyhow!("Space not found"))?
             }
-            SpaceOrSptr::Sptr(ref sptr) => {
+            Subject::Ptr(sptr) => {
                 src.get_ptr_outpoint(sptr)?
+                    .ok_or_else(|| anyhow::anyhow!("Sptr not found"))?
+            }
+            Subject::Numeric(numeric) => {
+                let key = NumericKey::from_numeric::<H>(numeric);
+                let sptr = src.get_numeric(&key)?
+                    .ok_or_else(|| anyhow::anyhow!("Numeric '{}' not found", numeric))?;
+                src.get_ptr_outpoint(&sptr)?
                     .ok_or_else(|| anyhow::anyhow!("Sptr not found"))?
             }
         };
@@ -531,14 +589,14 @@ impl SpacesWallet {
     /// Verify a schnorr signature against a space or sptr's public key
     pub fn verify_schnorr<H: KeyHasher, S: SpacesSource + PtrSource>(
         src: &mut S,
-        space_or_sptr: SpaceOrSptr,
+        subject: Subject,
         message: &[u8],
         signature: &schnorr::Signature,
     ) -> anyhow::Result<()> {
         use bitcoin::hashes::{sha256, Hash, HashEngine};
 
-        let script_pubkey = match space_or_sptr {
-            SpaceOrSptr::Space(ref label) => {
+        let script_pubkey = match &subject {
+            Subject::Space(label) => {
                 let space_key = SpaceKey::from(H::hash(label.as_ref()));
                 let outpoint = src.get_space_outpoint(&space_key)?
                     .ok_or_else(|| anyhow::anyhow!("Space not found"))?;
@@ -546,8 +604,18 @@ impl SpacesWallet {
                     .ok_or_else(|| anyhow::anyhow!("Space not found"))?;
                 spaceout.script_pubkey
             }
-            SpaceOrSptr::Sptr(ref sptr) => {
+            Subject::Ptr(sptr) => {
                 let outpoint = src.get_ptr_outpoint(sptr)?
+                    .ok_or_else(|| anyhow::anyhow!("Sptr not found"))?;
+                let ptrout = src.get_ptrout(&outpoint)?
+                    .ok_or_else(|| anyhow::anyhow!("Ptrout not found"))?;
+                ptrout.script_pubkey
+            }
+            Subject::Numeric(numeric) => {
+                let key = NumericKey::from_numeric::<H>(numeric);
+                let sptr = src.get_numeric(&key)?
+                    .ok_or_else(|| anyhow::anyhow!("Numeric '{}' not found", numeric))?;
+                let outpoint = src.get_ptr_outpoint(&sptr)?
                     .ok_or_else(|| anyhow::anyhow!("Sptr not found"))?;
                 let ptrout = src.get_ptrout(&outpoint)?
                     .ok_or_else(|| anyhow::anyhow!("Ptrout not found"))?;


### PR DESCRIPTION
Subspaces bound on-chain and sptrs in general will have a short resolvable numerical alias. We already have access to block height and tx position.

So an sptr created on-chain will internally be assigned a numerical alias of the format 

```
sptr: sptr1.....
numeric: #100000-22 // where 100000 is the block height and 22 is the tx position.
```

to be distinguished from spaces we use the hash tag `#` instead of `@`. This is an internal format that can later be improved on.



