### PR TITLE
 Replace spacedb block indexes and snumeric index with SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -57,15 +57,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayvec"
@@ -104,9 +104,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
 dependencies = [
  "anstyle",
  "bstr",
@@ -125,7 +125,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -379,25 +379,26 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -421,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecount"
@@ -465,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -499,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -509,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -521,27 +522,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -610,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -672,7 +673,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -689,9 +690,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -699,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -803,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -818,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -828,15 +829,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -845,38 +846,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -886,7 +887,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -922,20 +922,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1187,7 +1187,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1212,7 +1212,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1349,15 +1349,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -1371,15 +1371,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.20"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -1390,13 +1390,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.20"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1411,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1498,7 +1498,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1546,19 +1546,20 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags",
  "libc",
- "redox_syscall 0.7.1",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1580,9 +1581,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1695,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1788,29 +1789,29 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1825,6 +1826,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,9 +1839,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -1900,14 +1907,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -1931,7 +1938,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1955,8 +1962,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.36",
- "socket2 0.6.2",
+ "rustls 0.23.37",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1965,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1975,7 +1982,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -1993,16 +2000,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2012,6 +2019,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2083,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
 ]
@@ -2126,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2152,7 +2165,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2231,14 +2244,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2256,14 +2269,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -2311,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2334,9 +2347,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2362,7 +2375,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2417,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2458,7 +2471,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2469,7 +2482,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2587,12 +2600,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2614,12 +2627,13 @@ dependencies = [
 [[package]]
 name = "spacedb"
 version = "0.0.12"
-source = "git+https://github.com/spacesprotocol/spacedb#92c150ea5a368c7ec894ef3530992abd2f7d6012"
+source = "git+https://github.com/spacesprotocol/spacedb#d89676f5fb356e82e34032afaa4a5f16956ec712"
 dependencies = [
  "bincode",
  "borsh",
  "hex",
  "libc",
+ "rusqlite",
  "sha2",
 ]
 
@@ -2749,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.115"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2775,7 +2789,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2803,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -2814,14 +2828,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2857,7 +2871,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2868,7 +2882,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2911,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2926,9 +2940,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2936,20 +2950,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2968,7 +2982,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -3000,18 +3014,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3021,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.8+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
@@ -3108,7 +3122,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3134,9 +3148,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -3257,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3270,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3284,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3294,22 +3308,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -3350,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3634,9 +3648,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
@@ -3671,7 +3685,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn 2.0.115",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3687,7 +3701,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3742,7 +3756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -3764,28 +3778,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3805,7 +3819,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3845,7 +3859,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "spacedb"
 version = "0.0.12"
-source = "git+https://github.com/spacesprotocol/spacedb#d89676f5fb356e82e34032afaa4a5f16956ec712"
+source = "git+https://github.com/spacesprotocol/spacedb#43f23e78e4e5fffb8d89661a4b7f39ab43a5a644"
 dependencies = [
  "bincode",
  "borsh",
@@ -2658,6 +2658,7 @@ dependencies = [
  "predicates",
  "rand 0.8.5",
  "reqwest",
+ "rusqlite",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ anyhow = "1.0"
 hex = "0.4"
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
-spacedb = { git = "https://github.com/spacesprotocol/spacedb", version = "0.0.12" }
+spacedb = { git = "https://github.com/spacesprotocol/spacedb", features = ["hash-idx"] }
 base64 = "0.22"
 rand = "0.8"
 log = "0.4"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -48,6 +48,7 @@ colored = { workspace = true }
 tower = { workspace = true }
 hyper = { workspace = true }
 schemars = { version = "0.8", optional = true }
+rusqlite = { version = "0.31", features = ["bundled"] }
 
 [features]
 schema = ["schemars"]

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -15,7 +15,7 @@ use spaces_protocol::{
     validate::{TxChangeSet, UpdateKind, Validator},
     Bytes, Covenant, FullSpaceOut, RevokeReason, SpaceOut,
 };
-use spaces_nums::{CommitmentKey, NumericKey, CommitmentTipKey, DelegatorKey, NumOutpointKey};
+use spaces_nums::{CommitmentKey, CommitmentTipKey, DelegatorKey, NumOutpointKey};
 use spaces_wallet::bitcoin::{Network, Transaction};
 
 use crate::{
@@ -352,8 +352,7 @@ impl Client {
 
             // Num => Outpoint + Numeric => NumId
             state.insert_num_outpoint(create.num.id, outpoint.into());
-            let numeric_key = NumericKey::from_numeric::<Sha256>(&create.num.name);
-            state.insert_num(numeric_key, create.num.id);
+            state.insert_num(&create.num.name, create.num.id);
 
             // Outpoint => PtrOut
             let outpoint_key = NumOutpointKey::from_outpoint::<Sha256>(outpoint);

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -88,6 +88,11 @@ pub struct Args {
     /// Specify the number of anchors spaced will calculate for /root-anchors endpoint
     #[arg(long, env = "SPACED_NUM_ANCHORS")]
     num_anchors: Option<u32>,
+
+    /// Index internal node hashes for spaces & nums tree for
+    /// faster merkle proof generation (with build_chain_proof rpc)
+    #[arg(long, env = "SPACED_INDEX_NODE_HASHES", default_value = "false")]
+    index_node_hashes: bool,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum, Serialize, Deserialize)]
@@ -214,7 +219,8 @@ impl Args {
             ptr_genesis,
             &data_dir,
             args.block_index || args.block_index_full,
-            args.block_index || args.block_index_full, // TODO: option to index ptrs
+            args.block_index || args.block_index_full, // TODO: option to index ptrs,
+            args.index_node_hashes
         )?;
 
         let anchors_path = match args.skip_anchors {

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -219,8 +219,7 @@ impl Args {
             ptr_genesis,
             &data_dir,
             args.block_index || args.block_index_full,
-            args.block_index || args.block_index_full, // TODO: option to index ptrs,
-            args.index_node_hashes
+            args.index_node_hashes,
         )?;
 
         let anchors_path = match args.skip_anchors {

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -51,7 +51,7 @@ use tokio::{
 };
 use spaces_protocol::bitcoin::ScriptBuf;
 use spaces_protocol::hasher::Hash;
-use spaces_nums::{NumSource, FullNumOut, NumericKey, NumOut, Commitment, CommitmentTipKey, CommitmentKey, DelegatorKey, NumOutpointKey, RootAnchor, ChainProofRequest, NumKeyKind};
+use spaces_nums::{NumSource, FullNumOut, NumOut, Commitment, CommitmentTipKey, CommitmentKey, DelegatorKey, NumOutpointKey, RootAnchor, ChainProofRequest, NumKeyKind};
 use spaces_nums::snumeric::SNumeric;
 use spaces_nums::num_id::NumId;
 use spaces_wallet::bitcoin::hashes::sha256;
@@ -1829,8 +1829,7 @@ impl AsyncChainState {
         for key in request.nums {
             match key {
                 NumKeyKind::Num(numeric) => {
-                    let key = NumericKey::from_numeric::<Sha256>(&numeric);
-                    let id = state.get_num_id(&key)?;
+                    let id = state.get_num_id(&numeric)?;
                     if let Some(id) = id {
                         let fpt = state.get_num_info(&id)?
                             .expect("num id must exist if numeric exists");
@@ -1853,9 +1852,6 @@ impl AsyncChainState {
                             num_tree_keys.insert(operator_id.into());
                         }
 
-                    } else {
-                        // non-existence proof
-                        num_tree_keys.insert(key.into());
                     }
                 }
                 NumKeyKind::Id(id) => {
@@ -2190,8 +2186,7 @@ fn resolve_num_id(state: &mut Chain, subject: &Subject) -> anyhow::Result<NumId>
         Subject::NumId(id) => Ok(*id),
         Subject::Label(label) if label.is_numeric() => {
             let numeric: SNumeric = label.clone().try_into().unwrap();
-            let key = NumericKey::from_numeric::<Sha256>(&numeric);
-            state.get_num_id(&key)?
+            state.get_num_id(&numeric)?
                 .ok_or_else(|| anyhow!("numeric '{}' not found", numeric))
         }
         Subject::Label(_) => Err(anyhow!("expected a num id or numeric, not a space")),
@@ -2273,8 +2268,7 @@ fn get_delegation(state: &mut Chain, subject: &Subject) -> anyhow::Result<Option
     let (id, label) = match subject {
         Subject::Label(num) if num.is_numeric() => {
             let numeric: SNumeric = num.clone().try_into().expect("is_numeric");
-            let key = NumericKey::from_numeric::<Sha256>(&numeric);
-            let Some(num_id) = state.get_num_id(&key)? else {
+            let Some(num_id) = state.get_num_id(&numeric)? else {
                 return Ok(None);
             };
             let Some(num_info) = state.get_num_info(&num_id)? else {

--- a/client/src/store/chain.rs
+++ b/client/src/store/chain.rs
@@ -1,20 +1,23 @@
 use std::path::Path;
+use std::sync::Arc;
 use anyhow::{anyhow, Context};
 use log::info;
 use spacedb::Hash;
 use spaces_protocol::bitcoin::{BlockHash, OutPoint};
 use spaces_protocol::bitcoin::hashes::Hash as HashUtil;
 use spaces_protocol::constants::ChainAnchor;
-use spaces_protocol::hasher::{BaseHash, BidKey, OutpointKey, SpaceKey};
+use spaces_protocol::hasher::{BidKey, OutpointKey, SpaceKey};
 use spaces_protocol::prepare::SpacesSource;
 use spaces_protocol::{FullSpaceOut, SpaceOut};
 use spaces_protocol::slabel::SLabel;
-use spaces_nums::{Commitment, CommitmentKey, FullNumOut, NumericKey, NumOut, NumSource, CommitmentTipKey, DelegatorKey, NumOutpointKey, RootAnchor};
+use spaces_nums::{Commitment, CommitmentKey, FullNumOut, NumOut, NumSource, CommitmentTipKey, DelegatorKey, NumOutpointKey, RootAnchor};
 use spaces_nums::num_id::NumId;
+use spaces_nums::snumeric::SNumeric;
 use spaces_wallet::bitcoin::Network;
 use crate::client::{BlockMeta, NumBlockMeta};
 use crate::rpc::{BlockMetaWithHash, NumBlockMetaWithHash};
 use crate::store::{EncodableOutpoint, ReadTx, Sha256};
+use crate::store::index::SqliteIndex;
 use crate::store::ptrs::{NumChainState, NumLiveStore, NumStore};
 use crate::store::spaces::{RolloutEntry, RolloutIterator, SpLiveStore, SpStore, SpStoreUtils, SpacesState};
 
@@ -68,8 +71,8 @@ pub struct LiveStore {
 
 #[derive(Clone)]
 pub struct LiveIndex {
-    sp: Option<SpLiveStore>,
-    num: Option<NumLiveStore>,
+    block_index: bool,
+    db: Arc<SqliteIndex>,
 }
 
 impl SpacesSource for Chain {
@@ -103,8 +106,10 @@ impl NumSource for Chain {
         self.db.num.state.get_numout(outpoint)
     }
 
-    fn get_num_id(&mut self, key: &NumericKey) -> spaces_protocol::errors::Result<Option<NumId>> {
-        self.db.num.state.get_num_id(key)
+    fn get_num_id(&mut self, snum: &SNumeric) -> spaces_protocol::errors::Result<Option<NumId>> {
+        self.idx.db.get_snumeric(snum).map_err(|e| {
+            spaces_protocol::errors::Error::IO(format!("get_num_id: {}", e))
+        })
     }
 }
 
@@ -138,13 +143,11 @@ impl Chain {
         genesis: ChainAnchor,
         nums_genesis: ChainAnchor,
         dir: &Path,
-        index_spaces: bool,
-        index_ptrs: bool,
+        block_index: bool,
         index_hashes: bool,
     ) -> anyhow::Result<Self> {
         let proto_db_path = dir.join("root.sdb");
         let nums_db_path = dir.join("nums.sdb");
-        let initial_sp_sync = !proto_db_path.exists();
         let initial_num_sync = !nums_db_path.exists();
 
         let sp_store = SpStore::open(proto_db_path, index_hashes)?;
@@ -159,23 +162,14 @@ impl Chain {
             store: num_store,
         };
 
-
-        let mut sp_idx = None;
-
-        if index_spaces {
-            let current_tip = sp.state.tip.read().expect("tip");
-            sp_idx = Some(load_sp_index(dir, genesis, *current_tip, initial_sp_sync)?)
-        }
-
-        let mut num_idx = None;
-        if index_ptrs {
-            let current_tip = num.state.tip.read().expect("tip");
-            num_idx = Some(load_num_index(dir, nums_genesis, *current_tip, initial_num_sync)?)
-        }
+        let sqlite_index = SqliteIndex::open(dir)?;
 
         let chain = Chain {
             db: LiveStore { sp, num },
-            idx: LiveIndex { sp: sp_idx, num: num_idx },
+            idx: LiveIndex {
+                block_index,
+                db: Arc::new(sqlite_index),
+            },
             nums_genesis,
             cached_snapshot: None,
         };
@@ -209,8 +203,8 @@ impl Chain {
         block_hash: BlockHash,
         block: BlockMeta,
     ) -> anyhow::Result<()> {
-        if let Some(idx) = &self.idx.sp {
-            idx.state.insert(BaseHash::from_slice(block_hash.as_ref()), block);
+        if self.idx.block_index {
+            self.idx.db.insert_spaces_block(block_hash, block.height, block);
         }
         Ok(())
     }
@@ -220,8 +214,8 @@ impl Chain {
         block_hash: BlockHash,
         block: NumBlockMeta,
     ) -> anyhow::Result<()> {
-        if let Some(idx) = &self.idx.num {
-            idx.state.insert(BaseHash::from_slice(block_hash.as_ref()), block);
+        if self.idx.block_index {
+            self.idx.db.insert_nums_block(block_hash, block.height, block);
         }
         Ok(())
     }
@@ -237,17 +231,8 @@ impl Chain {
         self.db.sp.state.commit(checkpoint.clone(), spaces_batch)?;
         self.db.num.state.commit(checkpoint.clone(), ptrs_batch)?;
 
-        let sp_index_writer = self.idx.sp.clone();
-        if let Some(index) = sp_index_writer {
-            let tx = index.store.write().expect("write handle");
-            index.state.commit(checkpoint, tx)?;
-        }
+        self.idx.db.commit()?;
 
-        let pt_index_writer = self.idx.num.clone();
-        if let Some(index) = pt_index_writer {
-            let tx = index.store.write().expect("write handle");
-            index.state.commit(checkpoint, tx)?;
-        }
         Ok(true)
     }
 
@@ -260,11 +245,11 @@ impl Chain {
     }
 
     pub fn has_spaces_index(&self) -> bool {
-        self.idx.sp.is_some()
+        self.idx.block_index
     }
 
     pub fn has_nums_index(&self) -> bool {
-        self.idx.num.is_some()
+        self.idx.block_index
     }
 
     pub fn rollout_iter(&self) -> anyhow::Result<(RolloutIterator, ReadTx)> {
@@ -331,8 +316,8 @@ impl Chain {
         self.db.num.state.insert_num_outpoint(key, outpoint)
     }
 
-    pub(crate) fn insert_num(&self, key: NumericKey, id: NumId) {
-        self.db.num.state.insert_num(key, id)
+    pub(crate) fn insert_num(&self, snum: &SNumeric, id: NumId) {
+        self.idx.db.insert_snumeric(snum, id)
     }
 
     pub(crate) fn insert_delegator(&self, key: DelegatorKey, space: SLabel) {
@@ -381,34 +366,22 @@ impl Chain {
         self.db.sp.state.remove(key)
     }
 
-    pub fn get_spaces_block(&mut self, hash: BlockHash) -> anyhow::Result<Option<BlockMetaWithHash>> {
-        let idx = match &mut self.idx.sp  {
-            None => return Err(anyhow!("spaces index must be enabled")),
-            Some(idx) => idx
-        };
-        let key = BaseHash::from_slice(hash.as_ref());
-        let block = idx.state.get(key).context("could not retrieve block meta")?;
-        Ok(block.map(|b| {
-           BlockMetaWithHash {
-               hash,
-               block_meta: b,
-           }
-        }))
+    pub fn get_spaces_block(&self, hash: BlockHash) -> anyhow::Result<Option<BlockMetaWithHash>> {
+        if !self.idx.block_index {
+            return Err(anyhow!("spaces index must be enabled"));
+        }
+        let block = self.idx.db.get_spaces_block(&hash)
+            .context("could not retrieve block meta")?;
+        Ok(block.map(|b| BlockMetaWithHash { hash, block_meta: b }))
     }
 
-    pub fn get_nums_block(&mut self, hash: BlockHash) -> anyhow::Result<Option<NumBlockMetaWithHash>> {
-        let idx = match &mut self.idx.num {
-            None => return Err(anyhow!("ptrs index must be enabled")),
-            Some(idx) => idx
-        };
-        let key = BaseHash::from_slice(hash.as_ref());
-        let block = idx.state.get(key).context("could not retrieve num block meta")?;
-        Ok(block.map(|b| {
-           NumBlockMetaWithHash {
-               hash,
-               block_meta: b,
-           }
-        }))
+    pub fn get_nums_block(&self, hash: BlockHash) -> anyhow::Result<Option<NumBlockMetaWithHash>> {
+        if !self.idx.block_index {
+            return Err(anyhow!("ptrs index must be enabled"));
+        }
+        let block = self.idx.db.get_nums_block(&hash)
+            .context("could not retrieve num block meta")?;
+        Ok(block.map(|b| NumBlockMetaWithHash { hash, block_meta: b }))
     }
 
     pub fn restore<F>(&self, get_block_hash: F) -> anyhow::Result<()>
@@ -423,50 +396,27 @@ impl Chain {
         let iter = self.db.num.store.iter();
 
         let mut restore_point = None;
-        for (idx, snapshot) in iter.enumerate() {
+        for (_idx, snapshot) in iter.enumerate() {
             let snapshot = snapshot?;
             let anchor: ChainAnchor = snapshot.metadata().try_into()?;
             if anchor == required_checkpoint {
-                restore_point = Some((idx, snapshot, anchor));
+                restore_point = Some(snapshot);
                 break;
             }
         }
 
-        let (snapshot_idx, snapshot, checkpoint) =
-            match restore_point {
-                None => return Err(anyhow!("Could not restore nums to height = {}", required_checkpoint.height)),
-                Some(rp) => rp,
-            };
+        let snapshot = match restore_point {
+            None => return Err(anyhow!("Could not restore nums to height = {}", required_checkpoint.height)),
+            Some(s) => s,
+        };
 
-        info!("Restoring nums block={} height={}", checkpoint.hash, checkpoint.height);
-
-        if let Some(num_idx) = self.idx.num.as_ref() {
-            let idx = num_idx.store
-                .iter().skip(snapshot_idx).next();
-            if idx.is_none() {
-                return Err(anyhow!(
-                        "Could not restore num block index due to missing snapshot"
-                    ));
-            }
-            let idx = idx.unwrap()?;
-            let idx_checkpoint: ChainAnchor = idx.metadata().try_into()?;
-            if idx_checkpoint != checkpoint {
-                return Err(anyhow!(
-                        "num block index checkpoint does not match the num's checkpoint"
-                    ));
-            }
-            idx.rollback()
-                .context("could not rollback num block index snapshot")?;
-        }
+        info!("Restoring nums block={} height={}", required_checkpoint.hash, required_checkpoint.height);
 
         snapshot
             .rollback()
             .context("could not rollback num snapshot")?;
 
-        self.db.num.state.restore(checkpoint.clone());
-        if let Some(idx) = self.idx.num.as_ref() {
-            idx.state.restore(checkpoint);
-        }
+        self.db.num.state.restore(required_checkpoint);
 
         Ok(())
     }
@@ -476,7 +426,7 @@ impl Chain {
         F: Fn(u32) -> anyhow::Result<BlockHash>,
     {
         let chain_iter = self.db.sp.store.iter();
-        for (snapshot_index, snapshot) in chain_iter.enumerate() {
+        for (_snapshot_index, snapshot) in chain_iter.enumerate() {
             let chain_snapshot = snapshot?;
             let chain_checkpoint: ChainAnchor = chain_snapshot.metadata().try_into()?;
             if let Some(restore_to_height) = restore_to_height {
@@ -499,33 +449,12 @@ impl Chain {
                 chain_checkpoint.hash, chain_checkpoint.height
             );
 
-            if let Some(block_index) = self.idx.sp.as_ref() {
-                let index_snapshot = block_index.store.iter().skip(snapshot_index).next();
-                if index_snapshot.is_none() {
-                    return Err(anyhow!(
-                        "Could not restore block index due to missing snapshot"
-                    ));
-                }
-                let index_snapshot = index_snapshot.unwrap()?;
-                let index_checkpoint: ChainAnchor = index_snapshot.metadata().try_into()?;
-                if index_checkpoint != chain_checkpoint {
-                    return Err(anyhow!(
-                        "block index checkpoint does not match the chain's checkpoint"
-                    ));
-                }
-                index_snapshot
-                    .rollback()
-                    .context("could not rollback block index snapshot")?;
-            }
-
             chain_snapshot
                 .rollback()
                 .context("could not rollback chain snapshot")?;
 
             self.db.sp.state.restore(chain_checkpoint.clone());
-            if let Some(block_index) = self.idx.sp.as_ref() {
-                block_index.state.restore(chain_checkpoint)
-            }
+            self.idx.db.restore(chain_checkpoint.height)?;
             return Ok(chain_checkpoint);
         }
 
@@ -606,48 +535,3 @@ impl Chain {
 }
 
 
-fn load_sp_index(dir: &Path, genesis: ChainAnchor, tip: ChainAnchor, initial_sync: bool) -> anyhow::Result<SpLiveStore> {
-    let block_db_path = dir.join("block_index.sdb");
-    if !initial_sync && !block_db_path.exists() {
-        return Err(anyhow::anyhow!(
-                    "Block index must be enabled from the initial sync."
-                ));
-    }
-    let block_store = SpStore::open(block_db_path, false)?;
-    let index = SpLiveStore {
-        state: block_store.begin(&genesis).expect("begin block index"),
-        store: block_store,
-    };
-    {
-        let idx_tip = index.state.tip.read().expect("index");
-        if idx_tip.height != tip.height || idx_tip.hash != tip.hash {
-            return Err(anyhow::anyhow!(
-                        "Protocol and block index states don't match."
-                    ));
-        }
-    }
-    Ok(index)
-}
-
-fn load_num_index(dir: &Path, genesis: ChainAnchor, tip: ChainAnchor, initial_sync: bool) -> anyhow::Result<NumLiveStore> {
-    let block_db_path = dir.join("nums_block_index.sdb");
-    if !initial_sync && !block_db_path.exists() {
-        return Err(anyhow::anyhow!(
-                    "Num Block index must be enabled from the initial sync."
-                ));
-    }
-    let block_store = NumStore::open(block_db_path, false)?;
-    let index = NumLiveStore {
-        state: block_store.begin(&genesis).expect("begin block index"),
-        store: block_store,
-    };
-    {
-        let idx_tip = index.state.tip.read().expect("index");
-        if idx_tip.height != tip.height || idx_tip.hash != tip.hash {
-            return Err(anyhow::anyhow!(
-                        "Nums tip and block index states don't match."
-                    ));
-        }
-    }
-    Ok(index)
-}

--- a/client/src/store/chain.rs
+++ b/client/src/store/chain.rs
@@ -133,19 +133,27 @@ impl Chain {
         Ok(self.cached_snapshot.as_mut().unwrap())
     }
 
-    pub fn load(_network: Network, genesis: ChainAnchor, nums_genesis: ChainAnchor, dir: &Path, index_spaces: bool, index_ptrs: bool) -> anyhow::Result<Self> {
+    pub fn load(
+        _network: Network,
+        genesis: ChainAnchor,
+        nums_genesis: ChainAnchor,
+        dir: &Path,
+        index_spaces: bool,
+        index_ptrs: bool,
+        index_hashes: bool,
+    ) -> anyhow::Result<Self> {
         let proto_db_path = dir.join("root.sdb");
         let nums_db_path = dir.join("nums.sdb");
         let initial_sp_sync = !proto_db_path.exists();
         let initial_num_sync = !nums_db_path.exists();
 
-        let sp_store = SpStore::open(proto_db_path)?;
+        let sp_store = SpStore::open(proto_db_path, index_hashes)?;
         let sp = SpLiveStore {
             state: sp_store.begin(&genesis)?,
             store: sp_store,
         };
 
-        let num_store = NumStore::open(nums_db_path)?;
+        let num_store = NumStore::open(nums_db_path, index_hashes)?;
         let num = NumLiveStore {
             state: num_store.begin(&nums_genesis)?,
             store: num_store,
@@ -605,7 +613,7 @@ fn load_sp_index(dir: &Path, genesis: ChainAnchor, tip: ChainAnchor, initial_syn
                     "Block index must be enabled from the initial sync."
                 ));
     }
-    let block_store = SpStore::open(block_db_path)?;
+    let block_store = SpStore::open(block_db_path, false)?;
     let index = SpLiveStore {
         state: block_store.begin(&genesis).expect("begin block index"),
         store: block_store,
@@ -628,7 +636,7 @@ fn load_num_index(dir: &Path, genesis: ChainAnchor, tip: ChainAnchor, initial_sy
                     "Num Block index must be enabled from the initial sync."
                 ));
     }
-    let block_store = NumStore::open(block_db_path)?;
+    let block_store = NumStore::open(block_db_path, false)?;
     let index = NumLiveStore {
         state: block_store.begin(&genesis).expect("begin block index"),
         store: block_store,

--- a/client/src/store/index.rs
+++ b/client/src/store/index.rs
@@ -1,0 +1,251 @@
+use std::path::Path;
+use std::sync::{Mutex, RwLock};
+use anyhow::{anyhow, Result};
+use borsh::BorshDeserialize;
+use rusqlite::{params, Connection};
+use spaces_nums::num_id::NumId;
+use spaces_nums::snumeric::SNumeric;
+use spaces_protocol::bitcoin::BlockHash;
+
+use crate::client::{BlockMeta, NumBlockMeta};
+
+pub struct SqliteIndex {
+    conn: Mutex<Connection>,
+    staged: RwLock<Staged>,
+}
+
+#[derive(Default)]
+struct Staged {
+    spaces_blocks: Vec<(BlockHash, u32, BlockMeta)>,
+    nums_blocks: Vec<(BlockHash, u32, NumBlockMeta)>,
+    snumeric: Vec<(u32, u16, u16, NumId)>,
+}
+
+impl Staged {
+    fn clear(&mut self) {
+        self.spaces_blocks.clear();
+        self.nums_blocks.clear();
+        self.snumeric.clear();
+    }
+}
+
+impl SqliteIndex {
+    pub fn open(dir: &Path) -> Result<Self> {
+        let path = dir.join("index.sqlite");
+        let conn = Connection::open(path)?;
+
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+
+             CREATE TABLE IF NOT EXISTS spaces_blocks (
+                 block_height INTEGER NOT NULL,
+                 block_hash BLOB NOT NULL UNIQUE,
+                 data BLOB NOT NULL
+             );
+
+             CREATE TABLE IF NOT EXISTS nums_blocks (
+                 block_height INTEGER NOT NULL,
+                 block_hash BLOB NOT NULL UNIQUE,
+                 data BLOB NOT NULL
+             );
+
+             CREATE TABLE IF NOT EXISTS snumeric (
+                 block_height INTEGER NOT NULL,
+                 tx_pos INTEGER NOT NULL,
+                 vout INTEGER NOT NULL,
+                 num_id BLOB NOT NULL,
+                 PRIMARY KEY (block_height, tx_pos, vout)
+             ) WITHOUT ROWID;",
+        )?;
+
+        Ok(Self {
+            conn: Mutex::new(conn),
+            staged: RwLock::new(Staged::default()),
+        })
+    }
+
+    // --- Spaces block index ---
+
+    pub fn insert_spaces_block(&self, hash: BlockHash, height: u32, meta: BlockMeta) {
+        self.staged
+            .write()
+            .unwrap()
+            .spaces_blocks
+            .push((hash, height, meta));
+    }
+
+    pub fn get_spaces_block(&self, hash: &BlockHash) -> Result<Option<BlockMeta>> {
+        // Check staged first
+        {
+            let staged = self.staged.read().unwrap();
+            for (h, _, meta) in staged.spaces_blocks.iter().rev() {
+                if h == hash {
+                    return Ok(Some(meta.clone()));
+                }
+            }
+        }
+        // Fall back to sqlite
+        let conn = self.conn.lock().unwrap();
+        let mut stmt =
+            conn.prepare_cached("SELECT data FROM spaces_blocks WHERE block_hash = ?1")?;
+        let result = stmt.query_row(params![<BlockHash as AsRef<[u8]>>::as_ref(&hash)], |row| {
+            let data: Vec<u8> = row.get(0)?;
+            Ok(data)
+        });
+        match result {
+            Ok(data) => Ok(Some(
+                BlockMeta::try_from_slice(&data)
+                    .map_err(|e| anyhow!("deserialize BlockMeta: {}", e))?,
+            )),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    // --- Nums block index ---
+
+    pub fn insert_nums_block(&self, hash: BlockHash, height: u32, meta: NumBlockMeta) {
+        self.staged
+            .write()
+            .unwrap()
+            .nums_blocks
+            .push((hash, height, meta));
+    }
+
+    pub fn get_nums_block(&self, hash: &BlockHash) -> Result<Option<NumBlockMeta>> {
+        // Check staged first
+        {
+            let staged = self.staged.read().unwrap();
+            for (h, _, meta) in staged.nums_blocks.iter().rev() {
+                if h == hash {
+                    return Ok(Some(meta.clone()));
+                }
+            }
+        }
+        // Fall back to sqlite
+        let conn = self.conn.lock().unwrap();
+        let mut stmt =
+            conn.prepare_cached("SELECT data FROM nums_blocks WHERE block_hash = ?1")?;
+        let result = stmt.query_row(params![<BlockHash as AsRef<[u8]>>::as_ref(&hash)], |row| {
+            let data: Vec<u8> = row.get(0)?;
+            Ok(data)
+        });
+        match result {
+            Ok(data) => Ok(Some(
+                NumBlockMeta::try_from_slice(&data)
+                    .map_err(|e| anyhow!("deserialize NumBlockMeta: {}", e))?,
+            )),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    // --- SNumeric index ---
+
+    pub fn insert_snumeric(&self, snum: &SNumeric, id: NumId) {
+        self.staged.write().unwrap().snumeric.push((
+            snum.block(),
+            snum.tx_pos(),
+            snum.vout(),
+            id,
+        ));
+    }
+
+    pub fn get_snumeric(&self, snum: &SNumeric) -> Result<Option<NumId>> {
+        let block = snum.block();
+        let tx_pos = snum.tx_pos();
+        let vout = snum.vout();
+
+        // Check staged first
+        {
+            let staged = self.staged.read().unwrap();
+            for &(b, t, v, ref id) in staged.snumeric.iter().rev() {
+                if b == block && t == tx_pos && v == vout {
+                    return Ok(Some(*id));
+                }
+            }
+        }
+        // Fall back to sqlite
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare_cached(
+            "SELECT num_id FROM snumeric WHERE block_height = ?1 AND tx_pos = ?2 AND vout = ?3",
+        )?;
+        let result = stmt.query_row(params![block, tx_pos as u32, vout as u32], |row| {
+            let data: Vec<u8> = row.get(0)?;
+            Ok(data)
+        });
+        match result {
+            Ok(data) => {
+                if data.len() != 32 {
+                    return Err(anyhow!("invalid NumId length: {}", data.len()));
+                }
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&data);
+                Ok(Some(NumId::from_bytes(arr)))
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    // --- Commit / Restore ---
+
+    pub fn commit(&self) -> Result<()> {
+        let mut staged = self.staged.write().unwrap();
+        let conn = self.conn.lock().unwrap();
+
+        conn.execute_batch("BEGIN")?;
+
+        {
+            let mut stmt = conn.prepare_cached(
+                "INSERT OR REPLACE INTO spaces_blocks (block_height, block_hash, data) VALUES (?1, ?2, ?3)",
+            )?;
+            for (hash, height, meta) in staged.spaces_blocks.drain(..) {
+                let data = borsh::to_vec(&meta)?;
+                stmt.execute(params![height, <BlockHash as AsRef<[u8]>>::as_ref(&hash), data])?;
+            }
+        }
+
+        {
+            let mut stmt = conn.prepare_cached(
+                "INSERT OR REPLACE INTO nums_blocks (block_height, block_hash, data) VALUES (?1, ?2, ?3)",
+            )?;
+            for (hash, height, meta) in staged.nums_blocks.drain(..) {
+                let data = borsh::to_vec(&meta)?;
+                stmt.execute(params![height, <BlockHash as AsRef<[u8]>>::as_ref(&hash), data])?;
+            }
+        }
+
+        {
+            let mut stmt = conn.prepare_cached(
+                "INSERT OR REPLACE INTO snumeric (block_height, tx_pos, vout, num_id) VALUES (?1, ?2, ?3, ?4)",
+            )?;
+            for (block_height, tx_pos, vout, id) in staged.snumeric.drain(..) {
+                stmt.execute(params![block_height, tx_pos as u32, vout as u32, id.as_slice()])?;
+            }
+        }
+
+        conn.execute_batch("COMMIT")?;
+        Ok(())
+    }
+
+    pub fn restore(&self, to_height: u32) -> Result<()> {
+        self.staged.write().unwrap().clear();
+
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM spaces_blocks WHERE block_height > ?1",
+            params![to_height],
+        )?;
+        conn.execute(
+            "DELETE FROM nums_blocks WHERE block_height > ?1",
+            params![to_height],
+        )?;
+        conn.execute(
+            "DELETE FROM snumeric WHERE block_height > ?1",
+            params![to_height],
+        )?;
+        Ok(())
+    }
+}

--- a/client/src/store/mod.rs
+++ b/client/src/store/mod.rs
@@ -5,10 +5,12 @@ use spacedb::db::Database;
 use spacedb::{Configuration, Hash, NodeHasher, Sha256Hasher};
 use spacedb::tx::{ReadTransaction, WriteTransaction};
 use spaces_protocol::bitcoin::OutPoint;
+use crate::store::chain::ROOT_ANCHORS_COUNT;
 
 pub mod spaces;
 pub mod ptrs;
 pub mod chain;
+pub mod index;
 
 type SpaceDb = Database<Sha256Hasher>;
 type ReadTx = ReadTransaction<Sha256Hasher>;
@@ -46,7 +48,9 @@ impl spaces_protocol::hasher::KeyHasher for Sha256 {
 }
 
 fn open_db(path_buf: PathBuf, auto_hash_index: bool) -> anyhow::Result<Database<Sha256Hasher>> {
-    let mut config = Configuration::standard();
-    config.auto_hash_index = auto_hash_index;
+    let  config = Configuration::standard()
+        .with_auto_hash_index(auto_hash_index)
+        .with_hash_index_pruning(Some(ROOT_ANCHORS_COUNT as _));
+    
     Ok(Database::open_with_config(path_buf.to_str().unwrap(), config)?)
 }

--- a/client/src/store/mod.rs
+++ b/client/src/store/mod.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use borsh::{BorshDeserialize, BorshSerialize};
 use spacedb::db::Database;
-use spacedb::{Hash, NodeHasher, Sha256Hasher};
+use spacedb::{Configuration, Hash, NodeHasher, Sha256Hasher};
 use spacedb::tx::{ReadTransaction, WriteTransaction};
 use spaces_protocol::bitcoin::OutPoint;
 
@@ -42,4 +43,10 @@ impl spaces_protocol::hasher::KeyHasher for Sha256 {
     fn hash(data: &[u8]) -> spaces_protocol::hasher::Hash {
         Sha256Hasher::hash(data)
     }
+}
+
+fn open_db(path_buf: PathBuf, auto_hash_index: bool) -> anyhow::Result<Database<Sha256Hasher>> {
+    let mut config = Configuration::standard();
+    config.auto_hash_index = auto_hash_index;
+    Ok(Database::open_with_config(path_buf.to_str().unwrap(), config)?)
 }

--- a/client/src/store/ptrs.rs
+++ b/client/src/store/ptrs.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{BTreeMap},
-    fs::OpenOptions,
     io,
     io::ErrorKind,
     mem,
@@ -12,9 +11,8 @@ use anyhow::{anyhow, Context, Result};
 use borsh::{BorshDeserialize, BorshSerialize};
 use spacedb::{
     db::{Database, SnapshotIterator},
-    fs::FileBackend,
     tx::{ReadTransaction, WriteTransaction},
-    Configuration, Hash, Sha256Hasher,
+    Hash, Sha256Hasher,
 };
 use spaces_protocol::{
     bitcoin::{BlockHash, OutPoint},
@@ -24,7 +22,7 @@ use spaces_protocol::{
 use spaces_protocol::slabel::SLabel;
 use spaces_nums::{Commitment, CommitmentKey, FullNumOut, NumericKey, NumOut, NumSource, CommitmentTipKey, DelegatorKey, NumOutpointKey};
 use spaces_nums::num_id::NumId;
-use crate::store::{EncodableOutpoint, Sha256};
+use crate::store::{open_db, EncodableOutpoint, Sha256};
 
 type SpaceDb = Database<Sha256Hasher>;
 type ReadTx = ReadTransaction<Sha256Hasher>;
@@ -56,25 +54,14 @@ pub struct Staged {
 }
 
 impl NumStore {
-    pub fn open(path: PathBuf) -> Result<Self> {
-        let db = Self::open_db(path)?;
+    pub fn open(path: PathBuf, auto_hash_index: bool) -> Result<Self> {
+        let db = open_db(path, auto_hash_index)?;
         Ok(Self(db))
     }
 
     pub fn memory() -> Result<Self> {
         let db = Database::memory()?;
         Ok(Self(db))
-    }
-
-    fn open_db(path_buf: PathBuf) -> anyhow::Result<Database<Sha256Hasher>> {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(path_buf)?;
-
-        let config = Configuration::new().with_cache_size(1000000 /* 1MB */);
-        Ok(Database::new(Box::new(FileBackend::new(file)?), config)?)
     }
 
     pub fn iter(&self) -> SnapshotIterator<'_, Sha256Hasher> {

--- a/client/src/store/ptrs.rs
+++ b/client/src/store/ptrs.rs
@@ -20,7 +20,8 @@ use spaces_protocol::{
     hasher::{KeyHash},
 };
 use spaces_protocol::slabel::SLabel;
-use spaces_nums::{Commitment, CommitmentKey, FullNumOut, NumericKey, NumOut, NumSource, CommitmentTipKey, DelegatorKey, NumOutpointKey};
+use spaces_nums::{Commitment, CommitmentKey, FullNumOut, NumOut, NumSource, CommitmentTipKey, DelegatorKey, NumOutpointKey};
+use spaces_nums::snumeric::SNumeric;
 use spaces_nums::num_id::NumId;
 use crate::store::{open_db, EncodableOutpoint, Sha256};
 
@@ -102,7 +103,6 @@ pub trait NumChainState {
     fn remove_commitment_tip(&self, key: CommitmentTipKey);
     fn insert_delegator(&self, key: DelegatorKey, space: SLabel);
     fn insert_num_outpoint(&self, key: NumId, outpoint: EncodableOutpoint);
-    fn insert_num(&self, key: NumericKey, id: NumId);
 
     #[allow(dead_code)]
     fn get_num_info(
@@ -134,10 +134,6 @@ impl NumChainState for NumLiveSnapshot {
 
     fn insert_num_outpoint(&self, key: NumId, outpoint: EncodableOutpoint) {
         self.insert(key, outpoint)
-    }
-
-    fn insert_num(&self, key: NumericKey, id: NumId) {
-        self.insert(key, id)
     }
 
     fn get_num_info(&mut self, hash: &NumId) -> Result<Option<FullNumOut>> {
@@ -341,10 +337,7 @@ impl NumSource for NumLiveSnapshot {
         Ok(result)
     }
 
-    fn get_num_id(&mut self, key: &NumericKey) -> spaces_protocol::errors::Result<Option<NumId>> {
-        let result = self.get(*key).map_err(|err| {
-            spaces_protocol::errors::Error::IO(format!("getnumeric: {}", err.to_string()))
-        })?;
-        Ok(result)
+    fn get_num_id(&mut self, _snum: &SNumeric) -> spaces_protocol::errors::Result<Option<NumId>> {
+        panic!("not supported call chain.get_num_id")
     }
 }

--- a/client/src/store/spaces.rs
+++ b/client/src/store/spaces.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
-    fs::OpenOptions,
     io,
     io::ErrorKind,
     mem,
@@ -15,9 +14,8 @@ use jsonrpsee::core::Serialize;
 use serde::Deserialize;
 use spacedb::{
     db::{Database, SnapshotIterator},
-    fs::FileBackend,
     tx::KeyIterator,
-    Configuration, Hash, Sha256Hasher,
+    Hash, Sha256Hasher,
 };
 use spaces_protocol::{
     bitcoin::{BlockHash, OutPoint},
@@ -27,7 +25,7 @@ use spaces_protocol::{
     Covenant, FullSpaceOut, SpaceOut,
 };
 use spaces_nums::RootAnchor;
-use crate::store::{EncodableOutpoint, ReadTx, Sha256, SpaceDb, WriteMemory, WriteTx};
+use crate::store::{open_db, EncodableOutpoint, ReadTx, Sha256, SpaceDb, WriteMemory, WriteTx};
 
 #[derive(Clone)]
 pub struct SpStore(SpaceDb);
@@ -60,25 +58,14 @@ pub struct Staged {
 }
 
 impl SpStore {
-    pub fn open(path: PathBuf) -> Result<Self> {
-        let db = Self::open_db(path)?;
+    pub fn open(path: PathBuf, auto_hash_index: bool) -> Result<Self> {
+        let db = open_db(path, auto_hash_index)?;
         Ok(Self(db))
     }
 
     pub fn memory() -> Result<Self> {
         let db = Database::memory()?;
         Ok(Self(db))
-    }
-
-    fn open_db(path_buf: PathBuf) -> anyhow::Result<Database<Sha256Hasher>> {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(path_buf)?;
-
-        let config = Configuration::new().with_cache_size(1000000 /* 1MB */);
-        Ok(Database::new(Box::new(FileBackend::new(file)?), config)?)
     }
 
     pub fn iter(&self) -> SnapshotIterator<'_, Sha256Hasher> {

--- a/client/src/wallets.rs
+++ b/client/src/wallets.rs
@@ -46,7 +46,7 @@ use crate::{
 };
 use spaces_nums::num_id::{NumId, NumIdParseError, NUM_HRP};
 use spaces_nums::snumeric::SNumeric;
-use spaces_nums::{FullNumOut, NumericKey};
+use spaces_nums::FullNumOut;
 use spaces_nums::{DelegatorKey, NumOut, NumSource};
 use spaces_protocol::bitcoin::address::ParseError;
 use spaces_protocol::bitcoin::{Network, ScriptBuf};
@@ -380,9 +380,8 @@ fn resolve_subject_to_num_id<H: KeyHasher>(
         Subject::NumId(id) => Ok(*id),
         Subject::Label(label) if label.is_numeric() => {
             let numeric: SNumeric = label.clone().try_into().unwrap();
-            let key = NumericKey::from_numeric::<H>(&numeric);
             chain
-                .get_num_id(&key)?
+                .get_num_id(&numeric)?
                 .ok_or_else(|| anyhow!("numeric '{}' not found", numeric))
         }
         Subject::Label(label) => Err(anyhow!(
@@ -401,9 +400,8 @@ fn commit_params_to_req(
     let spk_id = match &p.subject {
         Subject::Label(label) if label.is_numeric() => {
             let numeric: SNumeric = label.clone().try_into().unwrap();
-            let key = NumericKey::from_numeric::<Sha256>(&numeric);
             let num_id = chain
-                .get_num_id(&key)?
+                .get_num_id(&numeric)?
                 .ok_or_else(|| anyhow!("commit: numeric '{}' not found", label))?;
             let num_info = chain
                 .get_num_info(&num_id)?
@@ -748,9 +746,8 @@ impl RpcWallet {
                 .clone()
                 .try_into()
                 .map_err(|e| anyhow::anyhow!("invalid numeric label: {}", e))?;
-            let key = NumericKey::from_numeric::<Sha256>(&numeric);
             let num_id = chain
-                .get_num_id(&key)?
+                .get_num_id(&numeric)?
                 .ok_or_else(|| anyhow::anyhow!("Numeric not found: {}", label))?;
             let num_info = chain
                 .get_num_info(&num_id)?
@@ -1264,8 +1261,7 @@ impl RpcWallet {
                 Address::from_script(script_pubkey.as_script(), network.fallback_network())?
             }
             ResolvableTarget::Numeric(numeric) => {
-                let key = NumericKey::from_numeric::<Sha256>(&numeric);
-                let snum = match chain.get_num_id(&key)? {
+                let snum = match chain.get_num_id(&numeric)? {
                     None => return Ok(None),
                     Some(snum) => snum,
                 };
@@ -1384,8 +1380,7 @@ impl RpcWallet {
                             }
                             Subject::Label(label) if label.is_numeric() => {
                                 let numeric: SNumeric = label.clone().try_into().unwrap();
-                                let key = NumericKey::from_numeric::<Sha256>(&numeric);
-                                let id = chain.get_num_id(&key)?.ok_or_else(|| {
+                                let id = chain.get_num_id(&numeric)?.ok_or_else(|| {
                                     anyhow!("transfer: numeric '{}' not found", numeric)
                                 })?;
                                 let num = match chain.get_num_info(&id)? {
@@ -1601,8 +1596,7 @@ impl RpcWallet {
                     match &params.subject {
                         Subject::Label(label) if label.is_numeric() => {
                             let numeric: SNumeric = label.clone().try_into().unwrap();
-                            let key = NumericKey::from_numeric::<Sha256>(&numeric);
-                            let id = chain.get_num_id(&key)?.ok_or_else(|| {
+                            let id = chain.get_num_id(&numeric)?.ok_or_else(|| {
                                 anyhow!("operate: numeric '{}' not found", label)
                             })?;
                             let num = match chain.get_num_info(&id)? {
@@ -2165,8 +2159,7 @@ fn find_delegate_utxo(chain: &mut Chain, subject: &Subject) -> anyhow::Result<Fu
                 .clone()
                 .try_into()
                 .expect("valid numeric");
-            let key = NumericKey::from_numeric::<Sha256>(&numeric);
-            let id = chain.get_num_id(&key)?.ok_or_else(|| {
+            let id = chain.get_num_id(&numeric)?.ok_or_else(|| {
                 anyhow!("delegate: numeric '{}' not found", label)
             })?;
             Some(id)

--- a/nums/src/lib.rs
+++ b/nums/src/lib.rs
@@ -48,7 +48,7 @@ pub trait NumSource {
         outpoint: &OutPoint,
     ) -> spaces_protocol::errors::Result<Option<NumOut>>;
 
-    fn get_num_id(&mut self, key: &NumericKey) -> spaces_protocol::errors::Result<Option<NumId>>;
+    fn get_num_id(&mut self, _snum: &SNumeric) -> spaces_protocol::errors::Result<Option<NumId>>;
 }
 
 #[derive(Debug, Clone)]

--- a/nums/src/num_id.rs
+++ b/nums/src/num_id.rs
@@ -14,6 +14,8 @@ pub struct NumId(pub(crate) [u8; 32]);
 
 impl NumId {
     #[inline]
+    pub fn from_bytes(bytes: [u8; 32]) -> Self { Self(bytes) }
+    #[inline]
     pub fn as_slice(&self) -> &[u8] { &self.0 }
     #[inline]
     pub fn to_bytes(self) -> [u8; 32] { self.0 }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -46,7 +46,7 @@ use spaces_protocol::{
     slabel::SLabel,
     Covenant, FullSpaceOut, Space,
 };
-use spaces_nums::{NumericKey, NumSource, num_id::{NumId, NUM_HRP}};
+use spaces_nums::{NumSource, num_id::{NumId, NUM_HRP}};
 use spaces_nums::snumeric::SNumeric;
 
 use crate::{
@@ -475,8 +475,7 @@ impl SpacesWallet {
         let outpoint = match &subject {
             Subject::Label(label) if label.is_numeric() => {
                 let numeric: SNumeric = label.clone().try_into().unwrap();
-                let key = NumericKey::from_numeric::<H>(&numeric);
-                let id = src.get_num_id(&key)?
+                let id = src.get_num_id(&numeric)?
                     .ok_or_else(|| anyhow::anyhow!("Numeric '{}' not found", numeric))?;
                 src.get_num_outpoint_by_id(&id)?
                     .ok_or_else(|| anyhow::anyhow!("Num id not found"))?
@@ -516,8 +515,7 @@ impl SpacesWallet {
         let script_pubkey = match &subject {
             Subject::Label(label) if label.is_numeric() => {
                 let numeric: SNumeric = label.clone().try_into().unwrap();
-                let key = NumericKey::from_numeric::<H>(&numeric);
-                let id = src.get_num_id(&key)?
+                let id = src.get_num_id(&numeric)?
                     .ok_or_else(|| anyhow::anyhow!("Numeric '{}' not found", numeric))?;
                 let outpoint = src.get_num_outpoint_by_id(&id)?
                     .ok_or_else(|| anyhow::anyhow!("Num id not found"))?;
@@ -584,8 +582,7 @@ impl SpacesWallet {
         let outpoint = match &subject {
             Subject::Label(label) if label.is_numeric() => {
                 let numeric: SNumeric = label.clone().try_into().unwrap();
-                let key = NumericKey::from_numeric::<H>(&numeric);
-                let id = src.get_num_id(&key)?
+                let id = src.get_num_id(&numeric)?
                     .ok_or_else(|| anyhow::anyhow!("Numeric '{}' not found", numeric))?;
                 src.get_num_outpoint_by_id(&id)?
                     .ok_or_else(|| anyhow::anyhow!("Num id not found"))?
@@ -633,8 +630,7 @@ impl SpacesWallet {
         let script_pubkey = match &subject {
             Subject::Label(label) if label.is_numeric() => {
                 let numeric: SNumeric = label.clone().try_into().unwrap();
-                let key = NumericKey::from_numeric::<H>(&numeric);
-                let id = src.get_num_id(&key)?
+                let id = src.get_num_id(&numeric)?
                     .ok_or_else(|| anyhow::anyhow!("Numeric '{}' not found", numeric))?;
                 let outpoint = src.get_num_outpoint_by_id(&id)?
                     .ok_or_else(|| anyhow::anyhow!("Num id not found"))?;


### PR DESCRIPTION
This PR:

- Adds --index_node_hashes flag to enable indexing hashes of internal nodes in spacedb for faster build_chain_proof. This is needed for certrelay since it builds proofs frequently. This flag is disabled by default.

- Replaces the spaces block index (block_index.sdb) and nums block index (nums_block_index.sdb) with a single SQLite database (index.sqlite), since these indexes don't need merkle proofs.

 - Moves the snumeric→NumId mapping out of the production nums tree into SQLite, eliminating duplicate entries that inflate the tree
 - Snumeric index uses a composite integer primary key (block_height, tx_pos, vout) instead of a 32-byte hash .Sequential inserts, faster lookups, no hashing needed.
 - Inserts are staged in memory and batch-flushed at the existing 36-block commit interval
 - Reorgs handled via DELETE WHERE block_height > ? instead of spacedb snapshot rollback
