### PR TITLE
Add --enable-pruning flag

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -19,7 +19,7 @@ use spaces_nums::{CommitmentKey, CommitmentTipKey, DelegatorKey, NumOutpointKey}
 use spaces_wallet::bitcoin::{Network, Transaction};
 
 use crate::{
-    source::BitcoinRpcError,
+    source::{BitcoinRpcError, BestChain},
 };
 use crate::source::BlockQueueResult;
 use crate::store::chain::{Chain};
@@ -31,7 +31,7 @@ pub trait BlockSource {
     fn get_median_time(&self) -> Result<u64, BitcoinRpcError>;
     fn in_mempool(&self, txid: &Txid, height: u32) -> Result<bool, BitcoinRpcError>;
     fn get_block_count(&self) -> Result<u64, BitcoinRpcError>;
-    fn get_best_chain(&self, tip: Option<u32>, expected_chain: Network) -> Result<Option<ChainAnchor>, BitcoinRpcError>;
+    fn get_best_chain(&self, tip: Option<u32>, expected_chain: Network) -> Result<BestChain, BitcoinRpcError>;
     fn get_blockchain_info(&self) -> Result<BlockchainInfo, BitcoinRpcError>;
     fn get_block_filter_by_height(&self, height: u32) -> Result<Option<BlockFilterRpc>, BitcoinRpcError>;
     fn queue_blocks(&self, heights: Vec<u32>) -> Result<(), BitcoinRpcError>;

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -93,6 +93,12 @@ pub struct Args {
     /// faster merkle proof generation (with build_chain_proof rpc)
     #[arg(long, env = "SPACED_INDEX_NODE_HASHES", default_value = "false")]
     index_node_hashes: bool,
+
+    /// Enable manual pruning of Bitcoin Core blocks after they have been
+    /// processed by spaced. Calls `pruneblockchain` RPC periodically,
+    /// keeping a buffer of blocks from tip to handle reorgs.
+    #[arg(long, env = "SPACED_ENABLE_PRUNING", default_value = "false")]
+    enable_pruning: bool,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum, Serialize, Deserialize)]
@@ -240,6 +246,7 @@ impl Args {
             synced: false,
             cbf: args.bitcoin_rpc_light,
             num_anchors: args.num_anchors.unwrap_or(ROOT_ANCHORS_COUNT),
+            enable_pruning: args.enable_pruning,
         })
     }
 }

--- a/client/src/source.rs
+++ b/client/src/source.rs
@@ -47,9 +47,25 @@ pub struct BlockFetcher {
 }
 
 pub enum BlockEvent {
+    /// Fully caught up with Bitcoin Core
     Tip(ChainAnchor),
     Block(ChainAnchor, Block),
     Error(BlockFetchError),
+    /// Bitcoin Core is still syncing; carries its current block height
+    Waiting(u32),
+}
+
+pub enum BestChain {
+    Tip(ChainAnchor),
+    /// Bitcoin Core is syncing, still below our height
+    Waiting(u32),
+    None,
+}
+
+enum SyncStatus {
+    NewTip(ChainAnchor),
+    AtTip,
+    Waiting(u32),
 }
 
 pub enum BitcoinRpcAuth {
@@ -179,6 +195,11 @@ impl BitcoinRpc {
     pub fn get_blockchain_info(&self) -> BitcoinRpcRequest {
         let params = serde_json::json!([]);
         self.make_request("getblockchaininfo", params)
+    }
+
+    pub fn prune_blockchain(&self, height: u32) -> BitcoinRpcRequest {
+        let params = serde_json::json!([height]);
+        self.make_request("pruneblockchain", params)
     }
     pub fn get_block_filter_by_height(&self, height: u32) -> BitcoinRpcRequest {
         let params = serde_json::json!([height]);
@@ -431,10 +452,11 @@ impl BlockFetcher {
         expected_chain: Network,
         source: &BitcoinBlockSource,
         start: ChainAnchor,
-    ) -> Result<Option<ChainAnchor>, BlockFetchError> {
+    ) -> Result<SyncStatus, BlockFetchError> {
         let tip = match source.get_best_chain(Some(start.height), expected_chain)? {
-            Some(tip) => tip,
-            None => return Ok(None),
+            BestChain::Tip(tip) => tip,
+            BestChain::Waiting(height) => return Ok(SyncStatus::Waiting(height)),
+            BestChain::None => return Ok(SyncStatus::AtTip),
         };
 
         if start.height > tip.height {
@@ -449,10 +471,10 @@ impl BlockFetcher {
 
         // If the chain didn't advance and the hashes match, no rescan is needed
         if tip.height == start.height && tip.hash == start.hash {
-            return Ok(None);
+            return Ok(SyncStatus::AtTip);
         }
 
-        Ok(Some(tip))
+        Ok(SyncStatus::NewTip(tip))
     }
 
     pub fn restart(&self, checkpoint: ChainAnchor, drain_receiver: &Receiver<BlockEvent>) {
@@ -484,8 +506,8 @@ impl BlockFetcher {
                 }
                 last_check = Instant::now();
 
-                let tip = match BlockFetcher::should_sync(chain, &task_src, checkpoint) {
-                    Ok(t) => t,
+                let status = match BlockFetcher::should_sync(chain, &task_src, checkpoint) {
+                    Ok(s) => s,
                     Err(e) => {
                         _ = task_sender.send(BlockEvent::Error(e));
                         std_wait(
@@ -496,37 +518,43 @@ impl BlockFetcher {
                     }
                 };
 
-                if let Some(tip) = tip {
-                    let res = Self::run_workers(
-                        job_id,
-                        current_task.clone(),
-                        task_src.clone(),
-                        task_sender.clone(),
-                        checkpoint,
-                        tip.height,
-                        num_workers,
-                    );
+                match status {
+                    SyncStatus::NewTip(tip) => {
+                        let res = Self::run_workers(
+                            job_id,
+                            current_task.clone(),
+                            task_src.clone(),
+                            task_sender.clone(),
+                            checkpoint,
+                            tip.height,
+                            num_workers,
+                        );
 
-                    match res {
-                        Ok(new_tip) => {
-                            checkpoint = new_tip;
-                        }
-                        Err(e) if matches!(e, BlockFetchError::RpcError(_)) => {
-                            _ = task_sender.send(BlockEvent::Error(e));
-                            std_wait(
-                                || current_task.load(Ordering::SeqCst) != job_id,
-                                Duration::from_secs(1),
-                            );
-                            continue;
-                        }
-                        Err(e) => {
-                            _ = task_sender.send(BlockEvent::Error(e));
-                            current_task.fetch_add(1, Ordering::SeqCst);
-                            return;
+                        match res {
+                            Ok(new_tip) => {
+                                checkpoint = new_tip;
+                            }
+                            Err(e) if matches!(e, BlockFetchError::RpcError(_)) => {
+                                _ = task_sender.send(BlockEvent::Error(e));
+                                std_wait(
+                                    || current_task.load(Ordering::SeqCst) != job_id,
+                                    Duration::from_secs(1),
+                                );
+                                continue;
+                            }
+                            Err(e) => {
+                                _ = task_sender.send(BlockEvent::Error(e));
+                                current_task.fetch_add(1, Ordering::SeqCst);
+                                return;
+                            }
                         }
                     }
-                } else {
-                    _ = task_sender.send(BlockEvent::Tip(checkpoint));
+                    SyncStatus::AtTip => {
+                        _ = task_sender.send(BlockEvent::Tip(checkpoint));
+                    }
+                    SyncStatus::Waiting(height) => {
+                        _ = task_sender.send(BlockEvent::Waiting(height));
+                    }
                 }
             }
         });
@@ -898,6 +926,11 @@ impl BitcoinBlockSource {
         let client = reqwest::blocking::Client::new();
         Self { client, rpc }
     }
+
+    pub fn prune_blockchain(&self, height: u32) -> Result<u64, BitcoinRpcError> {
+        self.rpc
+            .send_json_blocking(&self.client, &self.rpc.prune_blockchain(height))
+    }
 }
 
 impl BlockSource for BitcoinBlockSource {
@@ -954,7 +987,7 @@ impl BlockSource for BitcoinBlockSource {
             .send_json_blocking(&self.client, &self.rpc.get_block_count())?)
     }
 
-    fn get_best_chain(&self, tip: Option<u32>, expected_chain: Network) -> Result<Option<ChainAnchor>, BitcoinRpcError> {
+    fn get_best_chain(&self, tip: Option<u32>, expected_chain: Network) -> Result<BestChain, BitcoinRpcError> {
         #[derive(Deserialize)]
         struct Info {
             pub chain: String,
@@ -981,7 +1014,7 @@ impl BlockSource for BitcoinBlockSource {
         }
         if info.chain != expected_chain {
             warn!("Invalid chain from connected rpc node - expected {}, got {}", expected_chain, info.chain);
-            return Ok(None);
+            return Ok(BestChain::None);
         }
 
         let synced = info.headers == info.blocks;
@@ -1000,10 +1033,10 @@ impl BlockSource for BitcoinBlockSource {
 
         // If the source is still syncing, and we have a higher tip, wait.
         if !synced && tip.is_some_and(|tip| tip > info.blocks) {
-            return Ok(None);
+            return Ok(BestChain::Waiting(info.blocks));
         }
 
-        Ok(Some(best_chain))
+        Ok(BestChain::Tip(best_chain))
     }
 
     fn get_blockchain_info(&self) -> anyhow::Result<crate::client::BlockchainInfo, BitcoinRpcError> {

--- a/client/src/spaces.rs
+++ b/client/src/spaces.rs
@@ -17,6 +17,9 @@ use crate::{
 };
 use crate::store::chain::{Chain};
 
+/// Number of blocks to keep from tip when pruning
+const PRUNING_BUFFER: u32 = 120;
+
 pub struct Spaced {
     pub network: ExtendedNetwork,
     pub chain: Chain,
@@ -30,6 +33,7 @@ pub struct Spaced {
     pub synced: bool,
     pub cbf: bool,
     pub num_anchors: u32,
+    pub enable_pruning: bool,
 }
 
 impl Spaced {
@@ -54,6 +58,21 @@ impl Spaced {
         info!("Updating root anchors ...");
         self.chain.update_anchors(anchors_path, self.num_anchors)?;
         Ok(())
+    }
+
+    fn prune(&self, source: &BitcoinBlockSource, height: u32) {
+        let prune_height = height.saturating_sub(PRUNING_BUFFER);
+        if prune_height == 0 {
+            return;
+        }
+        match source.prune_blockchain(prune_height) {
+            Ok(pruned_up_to) => {
+                info!("Pruned blocks up to height {}", pruned_up_to);
+            }
+            Err(e) => {
+                warn!("Failed to prune: {} (is Bitcoin Core started with -prune=1?)", e);
+            }
+        }
     }
 
     pub fn handle_block(
@@ -92,6 +111,7 @@ impl Spaced {
     ) -> anyhow::Result<()> {
         let start_block = self.chain.tip();
         let mut node = Client::new(self.block_index_full);
+        let mut last_idle_prune = std::time::Instant::now();
 
         info!(
             "Start block={} height={}",
@@ -122,9 +142,18 @@ impl Spaced {
                             self.update_anchors()?;
                         }
                     }
+                    BlockEvent::Waiting(bitcoind_height) => {
+                        if self.enable_pruning && last_idle_prune.elapsed() >= Duration::from_secs(60) {
+                            self.prune(&source, bitcoind_height);
+                            last_idle_prune = std::time::Instant::now();
+                        }
+                    }
                     BlockEvent::Block(id, block) => {
                         self.handle_block(&mut node, id, block)?;
                         info!("block={} height={}", id.hash, id.height);
+                        if self.enable_pruning && id.height % PRUNING_BUFFER == 0 {
+                            self.prune(&source, id.height);
+                        }
                     }
                     BlockEvent::Error(e) if matches!(e, BlockFetchError::BlockMismatch) => {
                         if let Err(e) = self.restore(&source) {

--- a/client/src/wallets.rs
+++ b/client/src/wallets.rs
@@ -40,7 +40,7 @@ use crate::{
     config::ExtendedNetwork,
     rpc::{RpcWalletRequest, RpcWalletTxBuilder, WalletLoadRequest},
     source::{
-        BitcoinBlockSource, BitcoinRpc, BitcoinRpcError, BlockEvent, BlockFetchError, BlockFetcher,
+        BestChain, BitcoinBlockSource, BitcoinRpc, BitcoinRpcError, BlockEvent, BlockFetchError, BlockFetcher,
     },
     std_wait,
 };
@@ -593,7 +593,7 @@ impl RpcWallet {
 
                 let best_chain =
                     source.get_best_chain(Some(wallet_info.info.tip), wallet.config.network);
-                if let Ok(Some(best_chain)) = best_chain {
+                if let Ok(BestChain::Tip(best_chain)) = best_chain {
                     wallet_info.info.progress = calc_progress(
                         wallet.config.start_block,
                         wallet_info.info.tip,
@@ -959,13 +959,14 @@ impl RpcWallet {
                             wallet.commit()?;
                         }
                     }
+                    BlockEvent::Waiting(_) => {}
                     BlockEvent::Error(e) if matches!(e, BlockFetchError::BlockMismatch) => {
                         let mut checkpoint_in_chain = None;
                         let best_chain = match source
                             .get_best_chain(Some(wallet_tip.height), network.fallback_network())
                         {
-                            Ok(Some(best)) => best,
-                            Ok(None) => {
+                            Ok(BestChain::Tip(best)) => best,
+                            Ok(BestChain::Waiting(_)) | Ok(BestChain::None) => {
                                 warn!("Waiting for source to sync");
                                 fetcher.restart(wallet_tip, &receiver);
                                 continue;

--- a/client/tests/fetcher_tests.rs
+++ b/client/tests/fetcher_tests.rs
@@ -41,7 +41,7 @@ fn test_block_fetching_from_bitcoin_rpc() -> Result<()> {
             panic!("Test timed out after {:?}", timeout);
         }
         match receiver.try_recv() {
-            Ok(BlockEvent::Tip(_)) => {}
+            Ok(BlockEvent::Tip(_)) | Ok(BlockEvent::Waiting(_)) => {}
             Ok(BlockEvent::Block(id, _)) => {
                 height += 1;
                 if id.height == GENERATED_BLOCKS as u32 {


### PR DESCRIPTION
This PR:
  
- Adds --enable-pruning flag: Calls Bitcoin Core's pruneblockchain RPC to free disk space after blocks have been processed, keeping a 120-block buffer from tip.Calls prune every 120 blocks during sync and every 60 seconds while idle.
 
- Fixes BlockEvent::Tip emitting while waiting for Bitcoin Core: Previously BlockEvent::Tip was emitted both when fully synced and when Bitcoin Core was still syncing below activation height, incorrectly setting synced = true. Added BlockEvent::Waiting(u32) to distinguish the two cases carries Bitcoin Core's current block height for use by the pruning logic.
